### PR TITLE
add `Map` to NeoVM

### DIFF
--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -127,9 +127,13 @@
         SETITEM = 0xC4,
         NEWARRAY = 0xC5, //用作引用類型
         NEWSTRUCT = 0xC6, //用作值類型
+        NEWMAP = 0xC7,
         APPEND = 0xC8,
         REVERSE = 0xC9,
         REMOVE = 0xCA,
+        HASKEY = 0xCB,
+        KEYS = 0xCC,
+        VALUES = 0xCD,
 
         // Exceptions
         THROW = 0xF0,

--- a/src/neo-vm/StackItem.cs
+++ b/src/neo-vm/StackItem.cs
@@ -13,6 +13,15 @@ namespace Neo.VM
     {
         public abstract bool Equals(StackItem other);
 
+        public sealed override bool Equals(object obj)
+        {
+            if (obj == null) return false;
+            if (obj == this) return true;
+            if (obj is StackItem other)
+                return Equals(other);
+            return false;
+        }
+
         public static StackItem FromInterface(IInteropInterface value)
         {
             return new InteropInterface(value);
@@ -29,6 +38,17 @@ namespace Neo.VM
         }
 
         public abstract byte[] GetByteArray();
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                foreach (byte element in GetByteArray())
+                    hash = hash * 31 + element;
+                return hash;
+            }
+        }
 
         public virtual string GetString()
         {

--- a/src/neo-vm/Types/Array.cs
+++ b/src/neo-vm/Types/Array.cs
@@ -56,13 +56,7 @@ namespace Neo.VM.Types
 
         public override bool Equals(StackItem other)
         {
-            if (ReferenceEquals(this, other)) return true;
-            if (ReferenceEquals(null, other)) return false;
-            Array a = other as Array;
-            if (a == null)
-                return false;
-            else
-                return _array.SequenceEqual(a._array);
+            return ReferenceEquals(this, other);
         }
 
         public override bool GetBoolean()

--- a/src/neo-vm/Types/Array.cs
+++ b/src/neo-vm/Types/Array.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Neo.VM.Types
 {
-    public class Array : StackItem, IList<StackItem>
+    public class Array : StackItem, ICollection, IList<StackItem>
     {
         protected readonly List<StackItem> _array;
 
@@ -17,6 +17,9 @@ namespace Neo.VM.Types
 
         public int Count => _array.Count;
         public bool IsReadOnly => false;
+
+        bool ICollection.IsSynchronized => false;
+        object ICollection.SyncRoot => _array;
 
         public Array() : this(new List<StackItem>()) { }
 
@@ -45,6 +48,12 @@ namespace Neo.VM.Types
             _array.CopyTo(array, arrayIndex);
         }
 
+        void ICollection.CopyTo(System.Array array, int index)
+        {
+            foreach (StackItem item in _array)
+                array.SetValue(item, index++);
+        }
+
         public override bool Equals(StackItem other)
         {
             if (ReferenceEquals(this, other)) return true;
@@ -58,7 +67,7 @@ namespace Neo.VM.Types
 
         public override bool GetBoolean()
         {
-            return _array.Count > 0;
+            return true;
         }
 
         public override byte[] GetByteArray()

--- a/src/neo-vm/Types/Map.cs
+++ b/src/neo-vm/Types/Map.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Neo.VM.Types
+{
+    public class Map : StackItem, ICollection, IDictionary<StackItem, StackItem>
+    {
+        private readonly Dictionary<StackItem, StackItem> dictionary;
+
+        public StackItem this[StackItem key]
+        {
+            get => this.dictionary[key];
+            set => this.dictionary[key] = value;
+        }
+
+        public ICollection<StackItem> Keys => dictionary.Keys;
+        public ICollection<StackItem> Values => dictionary.Values;
+        public int Count => dictionary.Count;
+        public bool IsReadOnly => false;
+
+        bool ICollection.IsSynchronized => false;
+        object ICollection.SyncRoot => dictionary;
+
+        public Map() : this(new Dictionary<StackItem, StackItem>()) { }
+
+        public Map(Dictionary<StackItem, StackItem> value)
+        {
+            this.dictionary = value;
+        }
+
+        public void Add(StackItem key, StackItem value)
+        {
+            dictionary.Add(key, value);
+        }
+
+        void ICollection<KeyValuePair<StackItem, StackItem>>.Add(KeyValuePair<StackItem, StackItem> item)
+        {
+            dictionary.Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            dictionary.Clear();
+        }
+
+        bool ICollection<KeyValuePair<StackItem, StackItem>>.Contains(KeyValuePair<StackItem, StackItem> item)
+        {
+            return dictionary.ContainsKey(item.Key);
+        }
+
+        public bool ContainsKey(StackItem key)
+        {
+            return dictionary.ContainsKey(key);
+        }
+
+        void ICollection<KeyValuePair<StackItem, StackItem>>.CopyTo(KeyValuePair<StackItem, StackItem>[] array, int arrayIndex)
+        {
+            foreach (KeyValuePair<StackItem, StackItem> item in dictionary)
+                array[arrayIndex++] = item;
+        }
+
+        void ICollection.CopyTo(System.Array array, int index)
+        {
+            foreach (KeyValuePair<StackItem, StackItem> item in dictionary)
+                array.SetValue(item, index++);
+        }
+
+        public override bool Equals(StackItem other)
+        {
+            return false;
+        }
+
+        public override bool GetBoolean()
+        {
+            return true;
+        }
+
+        public override byte[] GetByteArray()
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator<KeyValuePair<StackItem, StackItem>> IEnumerable<KeyValuePair<StackItem, StackItem>>.GetEnumerator()
+        {
+            return dictionary.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return dictionary.GetEnumerator();
+        }
+
+        public bool Remove(StackItem key)
+        {
+            return dictionary.Remove(key);
+        }
+
+        bool ICollection<KeyValuePair<StackItem, StackItem>>.Remove(KeyValuePair<StackItem, StackItem> item)
+        {
+            return dictionary.Remove(item.Key);
+        }
+
+        public bool TryGetValue(StackItem key, out StackItem value)
+        {
+            return dictionary.TryGetValue(key, out value);
+        }
+    }
+}

--- a/src/neo-vm/Types/Map.cs
+++ b/src/neo-vm/Types/Map.cs
@@ -68,7 +68,7 @@ namespace Neo.VM.Types
 
         public override bool Equals(StackItem other)
         {
-            return false;
+            return ReferenceEquals(this, other);
         }
 
         public override bool GetBoolean()

--- a/src/neo-vm/neo-vm.csproj
+++ b/src/neo-vm/neo-vm.csproj
@@ -4,7 +4,7 @@
     <Copyright>2016-2017 The Neo Project</Copyright>
     <AssemblyTitle>Neo.VM</AssemblyTitle>
     <Description>Neo.VM</Description>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <Authors>The Neo Project</Authors>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <AssemblyName>Neo.VM</AssemblyName>


### PR DESCRIPTION
Implemented #27 (partially):
1. Add new type `Map`.
2. Add new opcodes: `NEWMAP`, `HASKEY`, `KEYS`, `VALUES`.
3. Modify the opcodes `ARRAYSIZE`, `PICKITEM`, `SETITEM`, `REMOVE` to support map.

close #27 