### PR TITLE
Remove one instruction in regular executions

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -47,8 +47,11 @@ namespace Neo.VM
         public void Execute()
         {
             State &= ~VMState.BREAK;
-            while (!State.HasFlag(VMState.HALT) && !State.HasFlag(VMState.FAULT) && !State.HasFlag(VMState.BREAK))
+            do
+            {
                 StepInto();
+            }
+            while (!State.HasFlag(VMState.HALT) && !State.HasFlag(VMState.FAULT) && !State.HasFlag(VMState.BREAK));
         }
 
         private void ExecuteOp(OpCode opcode, ExecutionContext context)


### PR DESCRIPTION
For one OpCode instruction for example:

With while:
``` CheckStates->StepInto[WithCheckState]->CheckState->Exit``` 
With do-while:
``` StepInto[WithCheckState]->CheckState->Exit``` 