### PR TITLE
Allow to override InteropService methods

### DIFF
--- a/src/neo-vm/InteropService.cs
+++ b/src/neo-vm/InteropService.cs
@@ -16,12 +16,12 @@ namespace Neo.VM
             Register("System.ExecutionEngine.GetEntryScriptHash", GetEntryScriptHash);
         }
 
-        protected void Register(string method, Func<ExecutionEngine, bool> handler)
+        protected virtual void Register(string method, Func<ExecutionEngine, bool> handler)
         {
             dictionary[method.ToInteropMethodHash()] = handler;
         }
 
-        internal bool Invoke(byte[] method, ExecutionEngine engine)
+        protected virtual bool Invoke(byte[] method, ExecutionEngine engine)
         {
             uint hash = method.Length == 4
                 ? BitConverter.ToUInt32(method, 0)


### PR DESCRIPTION
Is useful for neoSharp, we have our own InteropService for allow to plug and play the VM, so we need to use our class (extended)