### PR TITLE
Get base object from InteropInterface

### DIFF
--- a/src/neo-vm/Types/InteropInterface.cs
+++ b/src/neo-vm/Types/InteropInterface.cs
@@ -34,5 +34,10 @@ namespace Neo.VM.Types
         {
             return _object as T;
         }
+        
+        public object GetInterface()
+        {
+            return _object;
+        }
     }
 }


### PR DESCRIPTION
Allow to get the base object from `InteropInterface` without known the type