### PR TITLE
Add SafeReadBytes from VM

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -189,7 +189,8 @@ namespace Neo.VM
                         }
                         break;
                     case OpCode.SYSCALL:
-                        if (Service?.Invoke(context.OpReader.ReadVarBytes(252), this) != true)
+                        int length = context.OpReader.ReadByte();
+                        if ((length > 252) || (Service?.Invoke(context.OpReader.SafeReadBytes(length), this) != true))
                             State |= VMState.FAULT;
                         break;
 

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -58,7 +58,7 @@ namespace Neo.VM
         private void ExecuteOp(OpCode opcode, ExecutionContext context)
         {
             if (opcode >= OpCode.PUSHBYTES1 && opcode <= OpCode.PUSHBYTES75)
-                context.EvaluationStack.Push(context.OpReader.ReadBytes((byte)opcode));
+                context.EvaluationStack.Push(context.OpReader.SafeReadBytes((byte)opcode));
             else
                 switch (opcode)
                 {
@@ -67,13 +67,13 @@ namespace Neo.VM
                         context.EvaluationStack.Push(new byte[0]);
                         break;
                     case OpCode.PUSHDATA1:
-                        context.EvaluationStack.Push(context.OpReader.ReadBytes(context.OpReader.ReadByte()));
+                        context.EvaluationStack.Push(context.OpReader.SafeReadBytes(context.OpReader.ReadByte()));
                         break;
                     case OpCode.PUSHDATA2:
-                        context.EvaluationStack.Push(context.OpReader.ReadBytes(context.OpReader.ReadUInt16()));
+                        context.EvaluationStack.Push(context.OpReader.SafeReadBytes(context.OpReader.ReadUInt16()));
                         break;
                     case OpCode.PUSHDATA4:
-                        context.EvaluationStack.Push(context.OpReader.ReadBytes(context.OpReader.ReadInt32()));
+                        context.EvaluationStack.Push(context.OpReader.SafeReadBytes(context.OpReader.ReadInt32()));
                         break;
                     case OpCode.PUSHM1:
                     case OpCode.PUSH1:
@@ -166,7 +166,7 @@ namespace Neo.VM
                                 return;
                             }
 
-                            byte[] script_hash = context.OpReader.ReadBytes(20);
+                            byte[] script_hash = context.OpReader.SafeReadBytes(20);
                             if (script_hash.All(p => p == 0))
                             {
                                 script_hash = context.EvaluationStack.Pop().GetByteArray();
@@ -988,7 +988,7 @@ namespace Neo.VM
                             if (opcode == OpCode.CALL_ED || opcode == OpCode.CALL_EDT)
                                 script_hash = context.EvaluationStack.Pop().GetByteArray();
                             else
-                                script_hash = context.OpReader.ReadBytes(20);
+                                script_hash = context.OpReader.SafeReadBytes(20);
                             byte[] script = table.GetScript(script_hash);
                             if (script == null)
                             {

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -189,8 +189,7 @@ namespace Neo.VM
                         }
                         break;
                     case OpCode.SYSCALL:
-                        int length = context.OpReader.ReadByte();
-                        if ((length > 252) || (Service?.Invoke(context.OpReader.SafeReadBytes(length), this) != true))
+                        if (Service?.Invoke(context.OpReader.ReadVarBytes(252), this) != true)
                             State |= VMState.FAULT;
                         break;
 

--- a/src/neo-vm/Helper.cs
+++ b/src/neo-vm/Helper.cs
@@ -7,7 +7,7 @@ namespace Neo.VM
     {
         public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0X7fffffc7)
         {
-            return reader.ReadBytes((int)reader.ReadVarInt((ulong)max));
+            return reader.SafeReadBytes((int)reader.ReadVarInt((ulong)max));
         }
 
         public static ulong ReadVarInt(this BinaryReader reader, ulong max = ulong.MaxValue)

--- a/src/neo-vm/Helper.cs
+++ b/src/neo-vm/Helper.cs
@@ -5,6 +5,27 @@ namespace Neo.VM
 {
     internal static class Helper
     {
+        public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0X7fffffc7)
+        {
+            return reader.ReadBytes((int)reader.ReadVarInt((ulong)max));
+        }
+
+        public static ulong ReadVarInt(this BinaryReader reader, ulong max = ulong.MaxValue)
+        {
+            byte fb = reader.ReadByte();
+            ulong value;
+            if (fb == 0xFD)
+                value = reader.ReadUInt16();
+            else if (fb == 0xFE)
+                value = reader.ReadUInt32();
+            else if (fb == 0xFF)
+                value = reader.ReadUInt64();
+            else
+                value = fb;
+            if (value > max) throw new FormatException();
+            return value;
+        }
+
         public static byte[] SafeReadBytes(this BinaryReader reader, int max = 0x1000000)
         {
             if (max > 0x1000000 || !reader.BaseStream.CanSeek || reader.BaseStream.Length - reader.BaseStream.Position < max)

--- a/src/neo-vm/Helper.cs
+++ b/src/neo-vm/Helper.cs
@@ -26,11 +26,12 @@ namespace Neo.VM
             return value;
         }
 
-        public static byte[] SafeReadBytes(this BinaryReader reader, int max = 0x1000000)
+        public static byte[] SafeReadBytes(this BinaryReader reader, int count)
         {
-            if (max > 0x1000000 || !reader.BaseStream.CanSeek || reader.BaseStream.Length - reader.BaseStream.Position < max)
+            byte[] data = reader.ReadBytes(count);
+            if (data.Length < count)
                 throw new FormatException();
-            return reader.ReadBytes(max);
+            return data;
         }
     }
 }

--- a/src/neo-vm/Helper.cs
+++ b/src/neo-vm/Helper.cs
@@ -5,25 +5,11 @@ namespace Neo.VM
 {
     internal static class Helper
     {
-        public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0X7fffffc7)
+        public static byte[] SafeReadBytes(this BinaryReader reader, int max = 0x1000000)
         {
-            return reader.ReadBytes((int)reader.ReadVarInt((ulong)max));
-        }
-
-        public static ulong ReadVarInt(this BinaryReader reader, ulong max = ulong.MaxValue)
-        {
-            byte fb = reader.ReadByte();
-            ulong value;
-            if (fb == 0xFD)
-                value = reader.ReadUInt16();
-            else if (fb == 0xFE)
-                value = reader.ReadUInt32();
-            else if (fb == 0xFF)
-                value = reader.ReadUInt64();
-            else
-                value = fb;
-            if (value > max) throw new FormatException();
-            return value;
+            if((max > 0x1000000) || (!reader.BaseStream.CanSeek) || (reader.BaseStream.Length - reader.BaseStream.Position) < max))
+                throw new FormatException;
+            return reader.reader.ReadBytes(max);
         }
     }
 }

--- a/src/neo-vm/Helper.cs
+++ b/src/neo-vm/Helper.cs
@@ -7,8 +7,8 @@ namespace Neo.VM
     {
         public static byte[] SafeReadBytes(this BinaryReader reader, int max = 0x1000000)
         {
-            if((max > 0x1000000) || (!reader.BaseStream.CanSeek) || (reader.BaseStream.Length - reader.BaseStream.Position) < max))
-                throw new FormatException;
+            if (max > 0x1000000 || !reader.BaseStream.CanSeek || reader.BaseStream.Length - reader.BaseStream.Position < max)
+                throw new FormatException();
             return reader.ReadBytes(max);
         }
     }

--- a/src/neo-vm/Helper.cs
+++ b/src/neo-vm/Helper.cs
@@ -5,7 +5,7 @@ namespace Neo.VM
 {
     internal static class Helper
     {
-        public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0X7fffffc7)
+        public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0x10000000)
         {
             return reader.SafeReadBytes((int)reader.ReadVarInt((ulong)max));
         }

--- a/src/neo-vm/Helper.cs
+++ b/src/neo-vm/Helper.cs
@@ -9,7 +9,7 @@ namespace Neo.VM
         {
             if((max > 0x1000000) || (!reader.BaseStream.CanSeek) || (reader.BaseStream.Length - reader.BaseStream.Position) < max))
                 throw new FormatException;
-            return reader.reader.ReadBytes(max);
+            return reader.ReadBytes(max);
         }
     }
 }


### PR DESCRIPTION
I believe ReadVarBytes is not necessary for NeoVM, and it's even misleading now that its limits on NeoVM (int max = 0X7fffffc7) differ from Neo limits of the "same" function (int max = 0x1000000).
ReadVarInt was also duplicated, so it was removed too. 
A new function called SafeReadBytes (inspired by @shargon discussion https://github.com/neo-project/neo/pull/511) was added, and it can be reused inside Neo project if necessary.