### PR TITLE
Check for negative count in NEWARRAY/NEWSTRUCT

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1312,13 +1312,8 @@ namespace Neo.VM
                     case OpCode.NEWARRAY:
                         {
                             int count = (int)context.EvaluationStack.Pop().GetBigInteger();
-                            if (count < 0)
-                            {
-                                State = VMState.FAULT;
-                                return;
-                            }
-
-                            if (!CheckArraySize(count))
+                            
+                            if (count < 0 || !CheckArraySize(count))
                             {
                                 State = VMState.FAULT;
                                 return;
@@ -1342,13 +1337,8 @@ namespace Neo.VM
                     case OpCode.NEWSTRUCT:
                         {
                             int count = (int)context.EvaluationStack.Pop().GetBigInteger();
-                            if (count < 0)
-                            {
-                                State = VMState.FAULT;
-                                return;
-                            }
-
-                            if (!CheckArraySize(count))
+                            
+                            if (count < 0 || !CheckArraySize(count))
                             {
                                 State = VMState.FAULT;
                                 return;

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1312,6 +1312,11 @@ namespace Neo.VM
                     case OpCode.NEWARRAY:
                         {
                             int count = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (count < 0)
+                            {
+                                State = VMState.FAULT;
+                                return;
+                            }
 
                             if (!CheckArraySize(count))
                             {

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1312,7 +1312,7 @@ namespace Neo.VM
                     case OpCode.NEWARRAY:
                         {
                             int count = (int)context.EvaluationStack.Pop().GetBigInteger();
-                            
+
                             if (count < 0 || !CheckArraySize(count))
                             {
                                 State = VMState.FAULT;
@@ -1337,7 +1337,7 @@ namespace Neo.VM
                     case OpCode.NEWSTRUCT:
                         {
                             int count = (int)context.EvaluationStack.Pop().GetBigInteger();
-                            
+
                             if (count < 0 || !CheckArraySize(count))
                             {
                                 State = VMState.FAULT;

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1342,6 +1342,11 @@ namespace Neo.VM
                     case OpCode.NEWSTRUCT:
                         {
                             int count = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (count < 0)
+                            {
+                                State = VMState.FAULT;
+                                return;
+                            }
 
                             if (!CheckArraySize(count))
                             {


### PR DESCRIPTION
https://github.com/neo-project/neo-vm/blob/41724f6276bf8d21787c979f063fe8b79c0115b3/src/neo-vm/ExecutionEngine.cs#L1312-L1323

A negative `count` does not fail until it hits the for-loop on line 1323 which then seems to throw an exception into the `catch` here
https://github.com/neo-project/neo-vm/blob/41724f6276bf8d21787c979f063fe8b79c0115b3/src/neo-vm/ExecutionEngine.cs#L226-L233

We can potentially save quite some cycles if we do not have to execute `CheckArraySize` but exit early via the proposed addition.  The same holds true for `NEWSTRUCT`