### PR TITLE
Add Coverals to neo-vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 script:
  - dotnet restore
- - find test -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
+ - find * -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
  - dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,10 @@ before_install:
 
 script:
  - dotnet restore
- - dotnet test
+ - find test -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
+ - dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+
+after_success:
+  # After all tests OK, Send CodeDov report
+  - echo "Test Success - Branch($TRAVIS_BRANCH) Pull Request($TRAVIS_PULL_REQUEST) Tag($TRAVIS_TAG)"
+  - bash <(curl -s https://codecov.io/bash) -v

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 </p>
 
 <p align="center">
-  <a href='https://coveralls.io/github/shargon/neo-vm?branch=shargon-master'>
-    <img src='https://coveralls.io/repos/github/shargon/neo-vm/badge.svg?branch=shargon-master' alt='Coverage Status' />
+  <a href='https://coveralls.io/github/neo-project/neo-vm?branch=master'>
+    <img src='https://coveralls.io/repos/github/neo-project/neo-vm/badge.svg?branch=master' alt='Coverage Status' />
   </a>
   <a href="https://travis-ci.org/neo-project/neo-vm">
     <img src="https://travis-ci.org/neo-project/neo-vm.svg?branch=master">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
     width="250px">
 </p>
 
-<p align="center">      
+<p align="center">
+  <a href='https://coveralls.io/github/shargon/neo-vm?branch=shargon-master'>
+    <img src='https://coveralls.io/repos/github/shargon/neo-vm/badge.svg?branch=shargon-master' alt='Coverage Status' />
+  </a>
   <a href="https://travis-ci.org/neo-project/neo-vm">
     <img src="https://travis-ci.org/neo-project/neo-vm.svg?branch=master">
   </a>

--- a/tests/neo-vm.Tests/UtStruct.cs
+++ b/tests/neo-vm.Tests/UtStruct.cs
@@ -1,8 +1,9 @@
-﻿using Neo.VM.Types;
-using Xunit;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.VM.Types;
 
 namespace Neo.Test
 {
+    [TestClass]
     public class UtStruct
     {
         private readonly Struct @struct;
@@ -14,29 +15,29 @@ namespace Neo.Test
                 @struct = new Struct { @struct };
         }
 
-        [Fact]
+        [TestMethod]
         public void Clone()
         {
             Struct s1 = new Struct { 1, new Struct { 2 } };
             Struct s2 = s1.Clone();
             s1[0] = 3;
-            Assert.Equal(1, s2[0]);
+            Assert.AreEqual(1, s2[0]);
             ((Struct)s1[1])[0] = 3;
-            Assert.Equal(2, ((Struct)s2[1])[0]);
+            Assert.AreEqual(2, ((Struct)s2[1])[0]);
             @struct.Clone();
         }
 
-        [Fact]
+        [TestMethod]
 #pragma warning disable xUnit1024 // Test methods cannot have overloads
         public void Equals()
 #pragma warning restore xUnit1024 // Test methods cannot have overloads
         {
             Struct s1 = new Struct { 1, new Struct { 2 } };
             Struct s2 = new Struct { 1, new Struct { 2 } };
-            Assert.True(s1.Equals(s2));
+            Assert.IsTrue(s1.Equals(s2));
             Struct s3 = new Struct { 1, new Struct { 3 } };
-            Assert.False(s1.Equals(s3));
-            Assert.True(@struct.Equals(@struct.Clone()));
+            Assert.IsFalse(s1.Equals(s3));
+            Assert.IsTrue(@struct.Equals(@struct.Clone()));
         }
     }
 }

--- a/tests/neo-vm.Tests/UtVMJson.cs
+++ b/tests/neo-vm.Tests/UtVMJson.cs
@@ -1,23 +1,39 @@
 using System.IO;
 using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Test.Extensions;
 using Neo.Test.Types;
-using Xunit;
 
 namespace Neo.Test
 {
+    [TestClass]
     public class UtVMJson : VMJsonTestBase
     {
-        [Theory]
-        [InlineData("./Tests/Others")]
-        [InlineData("./Tests/OpCodes/Arrays")]
-        [InlineData("./Tests/OpCodes/Stack")]
-        [InlineData("./Tests/OpCodes/Splice")]
-        [InlineData("./Tests/OpCodes/Control")]
-        [InlineData("./Tests/OpCodes/Push")]
-        [InlineData("./Tests/OpCodes/Numeric")]
-        [InlineData("./Tests/OpCodes/Exceptions")]
-        public void TestJson(string path)
+        [TestMethod]
+        public void TestOthers() => TestJson("./Tests/Others");
+
+        [TestMethod]
+        public void TestOpCodesArrays() => TestJson("./Tests/OpCodes/Arrays");
+
+        [TestMethod]
+        public void TestOpCodesStack() => TestJson("./Tests/OpCodes/Stack");
+
+        [TestMethod]
+        public void TestOpCodesSplice() => TestJson("./Tests/OpCodes/Splice");
+
+        [TestMethod]
+        public void TestOpCodesControl() => TestJson("./Tests/OpCodes/Control");
+
+        [TestMethod]
+        public void TestOpCodesPush() => TestJson("./Tests/OpCodes/Push");
+
+        [TestMethod]
+        public void TestOpCodesNumeric() => TestJson("./Tests/OpCodes/Numeric");
+
+        [TestMethod]
+        public void TestOpCodesExceptions() => TestJson("./Tests/OpCodes/Exceptions");
+
+        private void TestJson(string path)
         {
             foreach (var file in Directory.GetFiles(path, "*.json", SearchOption.AllDirectories))
             {

--- a/tests/neo-vm.Tests/neo-vm.Tests.csproj
+++ b/tests/neo-vm.Tests/neo-vm.Tests.csproj
@@ -8,12 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With these changes we can begin to include coverage in all pull requests, it is very useful to deny pull requests that decrease coverage, it could also help to see which areas of the code don't have unit tests yet, and we can focus more on this.

It require few more steps from your side @erikzhang 

First we need to define the secure environment token for coverals (in travis settings):

![image](https://user-images.githubusercontent.com/3167973/55680561-74330300-591b-11e9-9918-3d6664e9f328.png)

We can get this token here, but first you need to give access to the repository to https://coveralls.io (like travis)

![image](https://user-images.githubusercontent.com/3167973/55680577-a47aa180-591b-11e9-91d4-76a379d7eda1.png)

With this, we should be able (if all of this changes are ok) to see comments like this (https://github.com/CityOfZion/neo-sharp/pull/560#issuecomment-445799994) in every pull request, and be able to see the areas without tests, and we can improve the coverage to 100%!

*PD: Maybe I forgot a step because it's the first time I set up coveralls. So @nunojusto please review it :)*
