### PR TITLE
ScriptBuilder unit tests

### DIFF
--- a/tests/neo-vm.Tests/Helpers/RandomHelper.cs
+++ b/tests/neo-vm.Tests/Helpers/RandomHelper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Neo.Test.Helpers
+{
+    public class RandomHelper
+    {
+        const string _randchars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        static Random _rand = new Random();
+
+        /// <summary>
+        /// Get random buffer
+        /// </summary>
+        /// <param name="length">Length</param>
+        /// <returns>Buffer</returns>
+        public static byte[] RandBuffer(int length)
+        {
+            var buffer = new byte[length];
+            _rand.NextBytes(buffer);
+            return buffer;
+        }
+
+        /// <summary>
+        /// Get random string
+        /// </summary>
+        /// <param name="length">Length</param>
+        /// <returns>Buffer</returns>
+        public static string RandString(int length)
+        {
+            var stringChars = new char[length];
+            var random = new Random();
+
+            for (int i = 0; i < stringChars.Length; i++)
+            {
+                stringChars[i] = _randchars[random.Next(_randchars.Length)];
+            }
+
+            return new string(stringChars);
+        }
+
+        /// <summary>
+        /// Get random short
+        /// </summary>
+        /// <returns>Int16</returns>
+        public static short RandInt16()
+        {
+            return (short)_rand.Next(short.MaxValue);
+        }
+    }
+}

--- a/tests/neo-vm.Tests/UtScriptBuilder.cs
+++ b/tests/neo-vm.Tests/UtScriptBuilder.cs
@@ -16,7 +16,10 @@ namespace Neo.Test
         {
             using (var script = new ScriptBuilder())
             {
+                Assert.AreEqual(0, script.Offset);
                 script.Emit(OpCode.NOP);
+                Assert.AreEqual(1, script.Offset);
+
                 CollectionAssert.AreEqual(new byte[] { 0x61 }, script.ToArray());
             }
 

--- a/tests/neo-vm.Tests/UtScriptBuilder.cs
+++ b/tests/neo-vm.Tests/UtScriptBuilder.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Test.Helpers;
+using Neo.VM;
+
+namespace Neo.Test
+{
+    [TestClass]
+    public class UtScriptBuilder
+    {
+        [TestMethod]
+        public void TestEmit()
+        {
+            using (var script = new ScriptBuilder())
+            {
+                script.Emit(OpCode.NOP);
+                CollectionAssert.AreEqual(new byte[] { 0x61 }, script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                script.Emit(OpCode.NOP, new byte[] { 0x66 });
+                CollectionAssert.AreEqual(new byte[] { 0x61, 0x66 }, script.ToArray());
+            }
+        }
+
+        [TestMethod]
+        public void TestEmitAppCall()
+        {
+            var scriptHash = RandomHelper.RandBuffer(20);
+
+            using (var script = new ScriptBuilder())
+            {
+                Assert.ThrowsException<ArgumentException>(() => script.EmitAppCall(new byte[1], true));
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                script.EmitAppCall(scriptHash, true);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.TAILCALL }.Concat(scriptHash).ToArray(), script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                script.EmitAppCall(scriptHash, false);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.APPCALL }.Concat(scriptHash).ToArray(), script.ToArray());
+            }
+        }
+
+        [TestMethod]
+        public void TestEmitSysCall()
+        {
+            using (var script = new ScriptBuilder())
+            {
+                Assert.ThrowsException<ArgumentNullException>(() => script.EmitSysCall(null));
+            }
+
+            for (byte x = 0; x < byte.MaxValue; x++)
+            {
+                var api = RandomHelper.RandString(x);
+
+                using (var script = new ScriptBuilder())
+                {
+                    if (x >= 1 && x <= 252)
+                    {
+                        script.EmitSysCall(api);
+                        CollectionAssert.AreEqual(new byte[] { (byte)OpCode.SYSCALL, (byte)api.Length }.Concat(Encoding.UTF8.GetBytes(api)).ToArray(), script.ToArray());
+                    }
+                    else
+                    {
+                        Assert.ThrowsException<ArgumentException>(() => script.EmitSysCall(RandomHelper.RandString(x)));
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void TestEmitJump()
+        {
+            var offset = RandomHelper.RandInt16();
+
+            foreach (OpCode op in Enum.GetValues(typeof(OpCode)))
+            {
+                using (var script = new ScriptBuilder())
+                {
+                    if (op != OpCode.JMP && op != OpCode.JMPIF && op != OpCode.JMPIFNOT && op != OpCode.CALL)
+                    {
+                        Assert.ThrowsException<ArgumentException>(() => script.EmitJump(op, offset));
+                    }
+                    else
+                    {
+                        script.EmitJump(op, offset);
+                        CollectionAssert.AreEqual(new byte[] { (byte)op }.Concat(BitConverter.GetBytes(offset)).ToArray(), script.ToArray());
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void TestEmitPushBigInteger()
+        {
+            using (var script = new ScriptBuilder())
+            {
+                script.EmitPush(BigInteger.MinusOne);
+                CollectionAssert.AreEqual(new byte[] { 0x4F }, script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                script.EmitPush(BigInteger.Zero);
+                CollectionAssert.AreEqual(new byte[] { 0x00 }, script.ToArray());
+            }
+
+            for (byte x = 1; x <= 16; x++)
+            {
+                using (var script = new ScriptBuilder())
+                {
+                    script.EmitPush(new BigInteger(x));
+                    CollectionAssert.AreEqual(new byte[] { (byte)(OpCode.PUSH1 - 1 + x) }, script.ToArray());
+                }
+            }
+
+            foreach (BigInteger test in new BigInteger[]
+                {
+                byte.MaxValue,
+                short.MinValue, short.MaxValue,
+                int.MinValue, int.MaxValue,
+                long.MinValue, long.MaxValue,
+                sbyte.MinValue, sbyte.MaxValue,
+                ushort.MaxValue,
+                uint.MaxValue,
+                new BigInteger(ulong.MaxValue)
+                }
+            )
+            {
+                using (var script = new ScriptBuilder())
+                {
+                    script.EmitPush(test);
+                    CollectionAssert.AreEqual(new byte[] { (byte)test.ToByteArray().Length }.Concat(test.ToByteArray()).ToArray(), script.ToArray());
+                }
+            }
+        }
+
+        [TestMethod]
+        public void TestEmitPushBool()
+        {
+            using (var script = new ScriptBuilder())
+            {
+                script.EmitPush(true);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHT }, script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                script.EmitPush(false);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHF }, script.ToArray());
+            }
+        }
+
+        [TestMethod]
+        public void TestEmitPushByteArray()
+        {
+            using (var script = new ScriptBuilder())
+            {
+                Assert.ThrowsException<ArgumentNullException>(() => script.EmitPush((byte[])null));
+            }
+
+            for (byte x = 0; x < 0x4B; x++)
+            {
+                using (var script = new ScriptBuilder())
+                {
+                    var data = RandomHelper.RandBuffer(x);
+
+                    script.EmitPush(data);
+                    CollectionAssert.AreEqual(new byte[] { x }.Concat(data).ToArray(), script.ToArray());
+                }
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                var data = RandomHelper.RandBuffer(0x4C);
+
+                script.EmitPush(data);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHDATA1, (byte)data.Length }.Concat(data).ToArray(), script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                var data = RandomHelper.RandBuffer(0x100);
+
+                script.EmitPush(data);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHDATA2 }.Concat(BitConverter.GetBytes((short)data.Length)).Concat(data).ToArray(), script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                var data = RandomHelper.RandBuffer(0x10000);
+
+                script.EmitPush(data);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHDATA4 }.Concat(BitConverter.GetBytes(data.Length)).Concat(data).ToArray(), script.ToArray());
+            }
+        }
+
+        [TestMethod]
+        public void TestEmitPushString()
+        {
+            using (var script = new ScriptBuilder())
+            {
+                Assert.ThrowsException<ArgumentNullException>(() => script.EmitPush((string)null));
+            }
+
+            for (byte x = 0; x < 0x4B; x++)
+            {
+                using (var script = new ScriptBuilder())
+                {
+                    var data = RandomHelper.RandString(x);
+
+                    script.EmitPush(data);
+                    CollectionAssert.AreEqual(new byte[] { x }.Concat(Encoding.UTF8.GetBytes(data)).ToArray(), script.ToArray());
+                }
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                var data = RandomHelper.RandString(0x4C);
+
+                script.EmitPush(data);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHDATA1, (byte)data.Length }.Concat(Encoding.UTF8.GetBytes(data)).ToArray(), script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                var data = RandomHelper.RandString(0x100);
+
+                script.EmitPush(data);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHDATA2 }.Concat(BitConverter.GetBytes((short)data.Length)).Concat(Encoding.UTF8.GetBytes(data)).ToArray(), script.ToArray());
+            }
+
+            using (var script = new ScriptBuilder())
+            {
+                var data = RandomHelper.RandString(0x10000);
+
+                script.EmitPush(data);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.PUSHDATA4 }.Concat(BitConverter.GetBytes(data.Length)).Concat(Encoding.UTF8.GetBytes(data)).ToArray(), script.ToArray());
+            }
+        }
+    }
+}


### PR DESCRIPTION
`EmitSysCall` must push the api hash instead of the string

@erikzhang what do you prefer. I can update this Pull Request or made another one