### PR TITLE
Allow to compress syscalls api methods

### DIFF
--- a/tests/neo-vm.Tests/UtScriptBuilder.cs
+++ b/tests/neo-vm.Tests/UtScriptBuilder.cs
@@ -61,6 +61,12 @@ namespace Neo.Test
                 Assert.ThrowsException<ArgumentNullException>(() => script.EmitSysCall(null));
             }
 
+            using (var script = new ScriptBuilder())
+            {
+                script.EmitSysCall("Neo.Runtime.GetTrigger", true);
+                CollectionAssert.AreEqual(new byte[] { (byte)OpCode.SYSCALL, 0x04, 0x75, 0xC8, 0x93, 0xE3 }.ToArray(), script.ToArray());
+            }
+
             for (byte x = 0; x < byte.MaxValue; x++)
             {
                 var api = RandomHelper.RandString(x);
@@ -69,12 +75,12 @@ namespace Neo.Test
                 {
                     if (x >= 1 && x <= 252)
                     {
-                        script.EmitSysCall(api);
+                        script.EmitSysCall(api, false);
                         CollectionAssert.AreEqual(new byte[] { (byte)OpCode.SYSCALL, (byte)api.Length }.Concat(Encoding.UTF8.GetBytes(api)).ToArray(), script.ToArray());
                     }
                     else
                     {
-                        Assert.ThrowsException<ArgumentException>(() => script.EmitSysCall(RandomHelper.RandString(x)));
+                        Assert.ThrowsException<ArgumentException>(() => script.EmitSysCall(RandomHelper.RandString(x), false));
                     }
                 }
             }


### PR DESCRIPTION
With this change we can build using the last version of `SYSCALL`