### PR TITLE
Remove Check on Equal and Not Equal

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -739,6 +739,7 @@ namespace Neo.VM
                         {
                             BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
                             BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            // We can avoid CheckBigInteger because the comparison is very fast
                             context.EvaluationStack.Push(x1 == x2);
                             CheckStackSize(true, -1);
                             break;
@@ -747,6 +748,7 @@ namespace Neo.VM
                         {
                             BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
                             BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            // We can avoid CheckBigInteger because the comparison is very fast
                             context.EvaluationStack.Push(x1 != x2);
                             CheckStackSize(true, -1);
                             break;

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -738,9 +738,7 @@ namespace Neo.VM
                     case OpCode.NUMEQUAL:
                         {
                             BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x2)) return false;
                             BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 == x2);
                             CheckStackSize(true, -1);
                             break;
@@ -748,9 +746,7 @@ namespace Neo.VM
                     case OpCode.NUMNOTEQUAL:
                         {
                             BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x2)) return false;
                             BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 != x2);
                             CheckStackSize(true, -1);
                             break;


### PR DESCRIPTION
Related to https://github.com/neo-project/neo-vm/issues/123 we can avoid these checks. 

According to the source code these comparison are very fast: https://referencesource.microsoft.com/#System.Numerics/System/Numerics/BigInteger.cs,192