### PR TITLE
Revert the restrictions of NUMEQUAL and NUMNOTEQUAL

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -738,9 +738,7 @@ namespace Neo.VM
                     case OpCode.NUMEQUAL:
                         {
                             BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x2)) return false;
                             BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 == x2);
                             CheckStackSize(true, -1);
                             break;
@@ -748,9 +746,7 @@ namespace Neo.VM
                     case OpCode.NUMNOTEQUAL:
                         {
                             BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x2)) return false;
                             BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 != x2);
                             CheckStackSize(true, -1);
                             break;


### PR DESCRIPTION
In NEO 3.0, we need to keep the restrictions on `NUMEQUAL` and `NUMNOTEQUAL`. So, from now there will be two master branches: `master` is for NEO 3.0, and `master-2.x` is for NEO 2.x.

Closes #123