### PR TITLE
Change Boolean false state

### DIFF
--- a/src/neo-vm/Types/Boolean.cs
+++ b/src/neo-vm/Types/Boolean.cs
@@ -6,7 +6,7 @@ namespace Neo.VM.Types
     public class Boolean : StackItem
     {
         private static readonly byte[] TRUE = { 1 };
-        private static readonly byte[] FALSE = new byte[0];
+        private static readonly byte[] FALSE = { 0 };
 
         private bool value;
 

--- a/tests/neo-vm.Tests/Tests/OpCodes/Splice/SIZE.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Splice/SIZE.json
@@ -167,7 +167,7 @@
                         [
                             {
                                 "type": "Integer",
-                                "value": 0
+                                "value": 1
                             }
                         ]
                     }


### PR DESCRIPTION
Closes https://github.com/neo-project/neo-vm/issues/129
a Boolean StackItem in either `false` or `true` state should always return at least 1 byte for `GetByteArray()`. This is the default behaviour in C#'s build in [BitConverter](https://docs.microsoft.com/en-us/dotnet/api/system.bitconverter) as well as many other languages. It is misleading for it to return an empty array as that will lead to a length/size of 0, whereas the item still takes up memory space.