### PR TITLE
optimize inc/dec

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -589,7 +589,6 @@ namespace Neo.VM
                     case OpCode.INC:
                         {
                             BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x)) return false;
                             x += 1;
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(x);
@@ -598,7 +597,6 @@ namespace Neo.VM
                     case OpCode.DEC:
                         {
                             BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
-                            if (!CheckBigInteger(x)) return false;
                             x -= 1;
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(x);


### PR DESCRIPTION
The `INC` and `DEC` instructions try to unnecessarily return early costing more CPU cycles than removing. 
https://github.com/neo-project/neo-vm/blob/a3f94445ff8de4fdea9388652f5dff9243d2c13b/src/neo-vm/ExecutionEngine.cs#L589-L595

We should assume that the majority of the contract executions operate in a compliant manner. That means that for the majority of the cases we now execute `CheckBigInteger()` twice where a single check (= line 594) would be sufficient. We're only interested in the final state and doing a `CheckBigInteger` just to prevent executing  a simple `x += 1` isn't worth the overhead of converting the stackitem to a bytearray, determining its length and doing a size check.