### PR TITLE
Expand PUSHBYTES2-PUSHBYTES74 to have human readable names

### DIFF
--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -47,27 +47,27 @@ namespace Neo.VM
         /// <summary>
         /// Push 10 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES10 = 0x0a,
+        PUSHBYTES10 = 0x0A,
         /// <summary>
         /// Push 11 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES11 = 0x0b,
+        PUSHBYTES11 = 0x0B,
         /// <summary>
         /// Push 12 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES12 = 0x0c,
+        PUSHBYTES12 = 0x0C,
         /// <summary>
         /// Push 13 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES13 = 0x0d,
+        PUSHBYTES13 = 0x0D,
         /// <summary>
         /// Push 14 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES14 = 0x0e,
+        PUSHBYTES14 = 0x0E,
         /// <summary>
         /// Push 15 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES15 = 0x0f,
+        PUSHBYTES15 = 0x0F,
         /// <summary>
         /// Push 16 bytes on the evaluation stack.
         /// </summary>
@@ -111,27 +111,27 @@ namespace Neo.VM
         /// <summary>
         /// Push 26 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES26 = 0x1a,
+        PUSHBYTES26 = 0x1A,
         /// <summary>
         /// Push 27 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES27 = 0x1b,
+        PUSHBYTES27 = 0x1B,
         /// <summary>
         /// Push 28 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES28 = 0x1c,
+        PUSHBYTES28 = 0x1C,
         /// <summary>
         /// Push 29 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES29 = 0x1d,
+        PUSHBYTES29 = 0x1D,
         /// <summary>
         /// Push 30 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES30 = 0x1e,
+        PUSHBYTES30 = 0x1E,
         /// <summary>
         /// Push 31 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES31 = 0x1f,
+        PUSHBYTES31 = 0x1F,
         /// <summary>
         /// Push 32 bytes on the evaluation stack.
         /// </summary>
@@ -175,27 +175,27 @@ namespace Neo.VM
         /// <summary>
         /// Push 42 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES42 = 0x2a,
+        PUSHBYTES42 = 0x2A,
         /// <summary>
         /// Push 43 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES43 = 0x2b,
+        PUSHBYTES43 = 0x2B,
         /// <summary>
         /// Push 44 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES44 = 0x2c,
+        PUSHBYTES44 = 0x2C,
         /// <summary>
         /// Push 45 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES45 = 0x2d,
+        PUSHBYTES45 = 0x2D,
         /// <summary>
         /// Push 46 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES46 = 0x2e,
+        PUSHBYTES46 = 0x2E,
         /// <summary>
         /// Push 47 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES47 = 0x2f,
+        PUSHBYTES47 = 0x2F,
         /// <summary>
         /// Push 48 bytes on the evaluation stack.
         /// </summary>
@@ -239,27 +239,27 @@ namespace Neo.VM
         /// <summary>
         /// Push 58 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES58 = 0x3a,
+        PUSHBYTES58 = 0x3A,
         /// <summary>
         /// Push 59 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES59 = 0x3b,
+        PUSHBYTES59 = 0x3B,
         /// <summary>
         /// Push 60 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES60 = 0x3c,
+        PUSHBYTES60 = 0x3C,
         /// <summary>
         /// Push 61 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES61 = 0x3d,
+        PUSHBYTES61 = 0x3D,
         /// <summary>
         /// Push 62 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES62 = 0x3e,
+        PUSHBYTES62 = 0x3E,
         /// <summary>
         /// Push 63 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES63 = 0x3f,
+        PUSHBYTES63 = 0x3F,
         /// <summary>
         /// Push 64 bytes on the evaluation stack.
         /// </summary>
@@ -303,11 +303,11 @@ namespace Neo.VM
         /// <summary>
         /// Push 74 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES74 = 0x4a,
+        PUSHBYTES74 = 0x4A,
         /// <summary>
         /// Push 75 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES75 = 0x4b,
+        PUSHBYTES75 = 0x4B,
         /// <summary>
         /// The next byte contains the number of bytes to be pushed onto the stack.
         /// </summary>

--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -11,63 +11,63 @@ namespace Neo.VM
         /// <summary>
         /// Push 1 byte on the evaluation stack.
         /// </summary>
-        PUSHBYTES1 = 0x1,
+        PUSHBYTES1 = 0x01,
         /// <summary>
         /// Push 2 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES2 = 0x2,
+        PUSHBYTES2 = 0x02,
         /// <summary>
         /// Push 3 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES3 = 0x3,
+        PUSHBYTES3 = 0x03,
         /// <summary>
         /// Push 4 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES4 = 0x4,
+        PUSHBYTES4 = 0x04,
         /// <summary>
         /// Push 5 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES5 = 0x5,
+        PUSHBYTES5 = 0x05,
         /// <summary>
         /// Push 6 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES6 = 0x6,
+        PUSHBYTES6 = 0x06,
         /// <summary>
         /// Push 7 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES7 = 0x7,
+        PUSHBYTES7 = 0x07,
         /// <summary>
         /// Push 8 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES8 = 0x8,
+        PUSHBYTES8 = 0x08,
         /// <summary>
         /// Push 9 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES9 = 0x9,
+        PUSHBYTES9 = 0x09,
         /// <summary>
         /// Push 10 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES10 = 0xa,
+        PUSHBYTES10 = 0x0a,
         /// <summary>
         /// Push 11 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES11 = 0xb,
+        PUSHBYTES11 = 0x0b,
         /// <summary>
         /// Push 12 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES12 = 0xc,
+        PUSHBYTES12 = 0x0c,
         /// <summary>
         /// Push 13 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES13 = 0xd,
+        PUSHBYTES13 = 0x0d,
         /// <summary>
         /// Push 14 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES14 = 0xe,
+        PUSHBYTES14 = 0x0e,
         /// <summary>
         /// Push 15 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES15 = 0xf,
+        PUSHBYTES15 = 0x0f,
         /// <summary>
         /// Push 16 bytes on the evaluation stack.
         /// </summary>
@@ -307,7 +307,8 @@ namespace Neo.VM
         /// <summary>
         /// Push 75 bytes on the evaluation stack.
         /// </summary>
-        PUSHBYTES75 = 0x4b,        /// <summary>
+        PUSHBYTES75 = 0x4b,
+        /// <summary>
         /// The next byte contains the number of bytes to be pushed onto the stack.
         /// </summary>
         PUSHDATA1 = 0x4C,

--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -9,11 +9,305 @@ namespace Neo.VM
         PUSH0 = 0x00,
         PUSHF = PUSH0,
         /// <summary>
-        /// 0x01-0x4B The next opcode bytes is data to be pushed onto the stack
+        /// Push 1 byte on the evaluation stack.
         /// </summary>
-        PUSHBYTES1 = 0x01,
-        PUSHBYTES75 = 0x4B,
+        PUSHBYTES1 = 0x1,
         /// <summary>
+        /// Push 2 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES2 = 0x2,
+        /// <summary>
+        /// Push 3 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES3 = 0x3,
+        /// <summary>
+        /// Push 4 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES4 = 0x4,
+        /// <summary>
+        /// Push 5 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES5 = 0x5,
+        /// <summary>
+        /// Push 6 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES6 = 0x6,
+        /// <summary>
+        /// Push 7 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES7 = 0x7,
+        /// <summary>
+        /// Push 8 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES8 = 0x8,
+        /// <summary>
+        /// Push 9 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES9 = 0x9,
+        /// <summary>
+        /// Push 10 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES10 = 0xa,
+        /// <summary>
+        /// Push 11 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES11 = 0xb,
+        /// <summary>
+        /// Push 12 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES12 = 0xc,
+        /// <summary>
+        /// Push 13 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES13 = 0xd,
+        /// <summary>
+        /// Push 14 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES14 = 0xe,
+        /// <summary>
+        /// Push 15 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES15 = 0xf,
+        /// <summary>
+        /// Push 16 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES16 = 0x10,
+        /// <summary>
+        /// Push 17 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES17 = 0x11,
+        /// <summary>
+        /// Push 18 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES18 = 0x12,
+        /// <summary>
+        /// Push 19 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES19 = 0x13,
+        /// <summary>
+        /// Push 20 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES20 = 0x14,
+        /// <summary>
+        /// Push 21 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES21 = 0x15,
+        /// <summary>
+        /// Push 22 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES22 = 0x16,
+        /// <summary>
+        /// Push 23 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES23 = 0x17,
+        /// <summary>
+        /// Push 24 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES24 = 0x18,
+        /// <summary>
+        /// Push 25 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES25 = 0x19,
+        /// <summary>
+        /// Push 26 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES26 = 0x1a,
+        /// <summary>
+        /// Push 27 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES27 = 0x1b,
+        /// <summary>
+        /// Push 28 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES28 = 0x1c,
+        /// <summary>
+        /// Push 29 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES29 = 0x1d,
+        /// <summary>
+        /// Push 30 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES30 = 0x1e,
+        /// <summary>
+        /// Push 31 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES31 = 0x1f,
+        /// <summary>
+        /// Push 32 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES32 = 0x20,
+        /// <summary>
+        /// Push 33 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES33 = 0x21,
+        /// <summary>
+        /// Push 34 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES34 = 0x22,
+        /// <summary>
+        /// Push 35 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES35 = 0x23,
+        /// <summary>
+        /// Push 36 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES36 = 0x24,
+        /// <summary>
+        /// Push 37 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES37 = 0x25,
+        /// <summary>
+        /// Push 38 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES38 = 0x26,
+        /// <summary>
+        /// Push 39 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES39 = 0x27,
+        /// <summary>
+        /// Push 40 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES40 = 0x28,
+        /// <summary>
+        /// Push 41 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES41 = 0x29,
+        /// <summary>
+        /// Push 42 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES42 = 0x2a,
+        /// <summary>
+        /// Push 43 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES43 = 0x2b,
+        /// <summary>
+        /// Push 44 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES44 = 0x2c,
+        /// <summary>
+        /// Push 45 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES45 = 0x2d,
+        /// <summary>
+        /// Push 46 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES46 = 0x2e,
+        /// <summary>
+        /// Push 47 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES47 = 0x2f,
+        /// <summary>
+        /// Push 48 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES48 = 0x30,
+        /// <summary>
+        /// Push 49 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES49 = 0x31,
+        /// <summary>
+        /// Push 50 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES50 = 0x32,
+        /// <summary>
+        /// Push 51 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES51 = 0x33,
+        /// <summary>
+        /// Push 52 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES52 = 0x34,
+        /// <summary>
+        /// Push 53 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES53 = 0x35,
+        /// <summary>
+        /// Push 54 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES54 = 0x36,
+        /// <summary>
+        /// Push 55 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES55 = 0x37,
+        /// <summary>
+        /// Push 56 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES56 = 0x38,
+        /// <summary>
+        /// Push 57 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES57 = 0x39,
+        /// <summary>
+        /// Push 58 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES58 = 0x3a,
+        /// <summary>
+        /// Push 59 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES59 = 0x3b,
+        /// <summary>
+        /// Push 60 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES60 = 0x3c,
+        /// <summary>
+        /// Push 61 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES61 = 0x3d,
+        /// <summary>
+        /// Push 62 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES62 = 0x3e,
+        /// <summary>
+        /// Push 63 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES63 = 0x3f,
+        /// <summary>
+        /// Push 64 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES64 = 0x40,
+        /// <summary>
+        /// Push 65 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES65 = 0x41,
+        /// <summary>
+        /// Push 66 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES66 = 0x42,
+        /// <summary>
+        /// Push 67 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES67 = 0x43,
+        /// <summary>
+        /// Push 68 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES68 = 0x44,
+        /// <summary>
+        /// Push 69 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES69 = 0x45,
+        /// <summary>
+        /// Push 70 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES70 = 0x46,
+        /// <summary>
+        /// Push 71 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES71 = 0x47,
+        /// <summary>
+        /// Push 72 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES72 = 0x48,
+        /// <summary>
+        /// Push 73 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES73 = 0x49,
+        /// <summary>
+        /// Push 74 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES74 = 0x4a,
+        /// <summary>
+        /// Push 75 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES75 = 0x4b,        /// <summary>
         /// The next byte contains the number of bytes to be pushed onto the stack.
         /// </summary>
         PUSHDATA1 = 0x4C,

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES10.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES10.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xA97BEE43046686A1A74FF80DC805C70952969DBA",
                                 "instructionPointer": 0,
-                                "nextInstruction": "10"
+                                "nextInstruction": "PUSHBYTES10"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES11.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES11.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xA0F6E6956BB8EDBAE2F0DC21C15F3866A2F9325D",
                                 "instructionPointer": 0,
-                                "nextInstruction": "11"
+                                "nextInstruction": "PUSHBYTES11"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES12.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES12.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x2484A2AE11D7BE74C7C7C404A425830CE9D33BA2",
                                 "instructionPointer": 0,
-                                "nextInstruction": "12"
+                                "nextInstruction": "PUSHBYTES12"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES13.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES13.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x147241032AD06A5B78D592CEC5AEA1B2EA0B1155",
                                 "instructionPointer": 0,
-                                "nextInstruction": "13"
+                                "nextInstruction": "PUSHBYTES13"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES14.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES14.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x964A81E09DA097CDC61EFF32E7ECF452708F136F",
                                 "instructionPointer": 0,
-                                "nextInstruction": "14"
+                                "nextInstruction": "PUSHBYTES14"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES15.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES15.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x62D8BFE509C6A034A0C5766C62B8185768B776CF",
                                 "instructionPointer": 0,
-                                "nextInstruction": "15"
+                                "nextInstruction": "PUSHBYTES15"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES16.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES16.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x2769B498166CE0C45A2BCD3FD614F082E01AC78D",
                                 "instructionPointer": 0,
-                                "nextInstruction": "16"
+                                "nextInstruction": "PUSHBYTES16"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES17.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES17.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xC2FBD27FEF2CF03E2B9BA82BCCFDCB8D3EE6B7B9",
                                 "instructionPointer": 0,
-                                "nextInstruction": "17"
+                                "nextInstruction": "PUSHBYTES17"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES18.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES18.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x9C2F52B95D7B1138C05374E3B83B1BEC334ADEC2",
                                 "instructionPointer": 0,
-                                "nextInstruction": "18"
+                                "nextInstruction": "PUSHBYTES18"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES19.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES19.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x1077B7607C5E88F7F64EC5F90A6DAB057ED2EB70",
                                 "instructionPointer": 0,
-                                "nextInstruction": "19"
+                                "nextInstruction": "PUSHBYTES19"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES2.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES2.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x2DFFE6985B066C4A37DA765149E3F5A06E1626C6",
                                 "instructionPointer": 0,
-                                "nextInstruction": "2"
+                                "nextInstruction": "PUSHBYTES2"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES20.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES20.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x04054FE10127587C06168629172F442C6AEEB708",
                                 "instructionPointer": 0,
-                                "nextInstruction": "20"
+                                "nextInstruction": "PUSHBYTES20"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES21.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES21.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x231BF230073FFA6FB600B2B9724BEC1E541DE135",
                                 "instructionPointer": 0,
-                                "nextInstruction": "21"
+                                "nextInstruction": "PUSHBYTES21"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES22.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES22.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x857BB1B2DB65F5812F70B1E7285A66366B6C23BA",
                                 "instructionPointer": 0,
-                                "nextInstruction": "22"
+                                "nextInstruction": "PUSHBYTES22"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES23.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES23.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x43810B9FE5BA611595F4D075FEA2C131E737D158",
                                 "instructionPointer": 0,
-                                "nextInstruction": "23"
+                                "nextInstruction": "PUSHBYTES23"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES24.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES24.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x95653AC7C4E6A8D131B4BF4E86D0D3F5402884C2",
                                 "instructionPointer": 0,
-                                "nextInstruction": "24"
+                                "nextInstruction": "PUSHBYTES24"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES25.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES25.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x53ED834916370006032B745D7162AB90C0041899",
                                 "instructionPointer": 0,
-                                "nextInstruction": "25"
+                                "nextInstruction": "PUSHBYTES25"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES26.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES26.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x20C908EBD966E1D73EAEF4496C38F07E6F9CAE4B",
                                 "instructionPointer": 0,
-                                "nextInstruction": "26"
+                                "nextInstruction": "PUSHBYTES26"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES27.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES27.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x7AD8F18AAC249E1630E01AE974C4ECA430562B19",
                                 "instructionPointer": 0,
-                                "nextInstruction": "27"
+                                "nextInstruction": "PUSHBYTES27"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES28.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES28.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xB27E7638A7F88373C62D847E64F9C5B79754F8D2",
                                 "instructionPointer": 0,
-                                "nextInstruction": "28"
+                                "nextInstruction": "PUSHBYTES28"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES29.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES29.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xEFA120A18BDEA95EF5EA659465100CC50FD60931",
                                 "instructionPointer": 0,
-                                "nextInstruction": "29"
+                                "nextInstruction": "PUSHBYTES29"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES3.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES3.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xBA0295325CBCCD31131267C75563A0E7FF0AEC37",
                                 "instructionPointer": 0,
-                                "nextInstruction": "3"
+                                "nextInstruction": "PUSHBYTES3"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES30.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES30.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x0791468686F5ECA4090FBC279E8E3FDFEF32CB1D",
                                 "instructionPointer": 0,
-                                "nextInstruction": "30"
+                                "nextInstruction": "PUSHBYTES30"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES31.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES31.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x11CFFA420E19CA18FDF6AE2ED1FF93BC6305136F",
                                 "instructionPointer": 0,
-                                "nextInstruction": "31"
+                                "nextInstruction": "PUSHBYTES31"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES32.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES32.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x47DC93206F33A292C405C2163BCA3BB4D957562F",
                                 "instructionPointer": 0,
-                                "nextInstruction": "32"
+                                "nextInstruction": "PUSHBYTES32"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES33.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES33.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xAF03A37073E3705175F85A270F4AD27C43C423FC",
                                 "instructionPointer": 0,
-                                "nextInstruction": "33"
+                                "nextInstruction": "PUSHBYTES33"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES34.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES34.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x191CC4B2A7690F74F6FA24377F5D72C6576203F4",
                                 "instructionPointer": 0,
-                                "nextInstruction": "34"
+                                "nextInstruction": "PUSHBYTES34"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES35.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES35.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x8F3E7A40A9A872380DF2FCD9FB35251FB27FB61E",
                                 "instructionPointer": 0,
-                                "nextInstruction": "35"
+                                "nextInstruction": "PUSHBYTES35"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES36.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES36.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xF74C4F446A0FDA3A6DAB56FAAFC2637837714662",
                                 "instructionPointer": 0,
-                                "nextInstruction": "36"
+                                "nextInstruction": "PUSHBYTES36"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES37.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES37.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x34A48D5E0A3BCBF5305267AA26BB567615F13B76",
                                 "instructionPointer": 0,
-                                "nextInstruction": "37"
+                                "nextInstruction": "PUSHBYTES37"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES38.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES38.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x877A6DBAD5ACAD77B0CBBA7E508E24D9C69545C6",
                                 "instructionPointer": 0,
-                                "nextInstruction": "38"
+                                "nextInstruction": "PUSHBYTES38"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES39.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES39.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x4E47469CB5485465C62ABAB22512BD1BE4EEC1A4",
                                 "instructionPointer": 0,
-                                "nextInstruction": "39"
+                                "nextInstruction": "PUSHBYTES39"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES4.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES4.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x68F7C1822B9B00760A1614ED814CC18CD0B05057",
                                 "instructionPointer": 0,
-                                "nextInstruction": "4"
+                                "nextInstruction": "PUSHBYTES4"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES40.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES40.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xBE39F483A9674C2790CCB2A94D08702F2D47BD75",
                                 "instructionPointer": 0,
-                                "nextInstruction": "40"
+                                "nextInstruction": "PUSHBYTES40"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES41.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES41.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x4075AAB23FEE7CE53227B3A8D9565D12DCBACD0C",
                                 "instructionPointer": 0,
-                                "nextInstruction": "41"
+                                "nextInstruction": "PUSHBYTES41"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES42.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES42.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xEBE71CBC5C230E5D8C8C493B6AA73EF7DA80E9AF",
                                 "instructionPointer": 0,
-                                "nextInstruction": "42"
+                                "nextInstruction": "PUSHBYTES42"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES43.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES43.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x141183120097883379B742599BB2B9816C5F04EC",
                                 "instructionPointer": 0,
-                                "nextInstruction": "43"
+                                "nextInstruction": "PUSHBYTES43"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES44.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES44.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x692CDDC9DFF08313BAA6B75EC7B2B1570E371723",
                                 "instructionPointer": 0,
-                                "nextInstruction": "44"
+                                "nextInstruction": "PUSHBYTES44"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES45.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES45.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xC84A7AB81BE34A5F2B5B62A1176C31635FA0A009",
                                 "instructionPointer": 0,
-                                "nextInstruction": "45"
+                                "nextInstruction": "PUSHBYTES45"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES46.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES46.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xC86514A35EDB5888CB27FA3804253A7450BED1DF",
                                 "instructionPointer": 0,
-                                "nextInstruction": "46"
+                                "nextInstruction": "PUSHBYTES46"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES47.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES47.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xA63E514ACA5A35D7979DB97BC77F927E92F58FFF",
                                 "instructionPointer": 0,
-                                "nextInstruction": "47"
+                                "nextInstruction": "PUSHBYTES47"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES48.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES48.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xC4771A90BCBA27F6E456930482F0411BA8D1D12C",
                                 "instructionPointer": 0,
-                                "nextInstruction": "48"
+                                "nextInstruction": "PUSHBYTES48"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES49.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES49.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x5B2D04707E30446303980C6AE06251716C529476",
                                 "instructionPointer": 0,
-                                "nextInstruction": "49"
+                                "nextInstruction": "PUSHBYTES49"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES5.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES5.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xE4A4EE65546A2CE52F23CFBE317A0A8DC7C49519",
                                 "instructionPointer": 0,
-                                "nextInstruction": "5"
+                                "nextInstruction": "PUSHBYTES5"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES50.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES50.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x7ED6A05B65E01B09FBFCFBCBB190101021697FA3",
                                 "instructionPointer": 0,
-                                "nextInstruction": "50"
+                                "nextInstruction": "PUSHBYTES50"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES51.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES51.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x8E90FCF67AA647C50CCEBE17E49084730AD2086E",
                                 "instructionPointer": 0,
-                                "nextInstruction": "51"
+                                "nextInstruction": "PUSHBYTES51"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES52.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES52.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xB76EBEB82B40F7EB4E269DEC38DB56928CCF59F9",
                                 "instructionPointer": 0,
-                                "nextInstruction": "52"
+                                "nextInstruction": "PUSHBYTES52"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES53.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES53.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x92F69B69389738E5E47A787EE9A9BA36D6B4A051",
                                 "instructionPointer": 0,
-                                "nextInstruction": "53"
+                                "nextInstruction": "PUSHBYTES53"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES54.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES54.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x55F54F333D8132A2B0441DF9F52F0CDB9FD2A466",
                                 "instructionPointer": 0,
-                                "nextInstruction": "54"
+                                "nextInstruction": "PUSHBYTES54"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES55.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES55.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xB21D47E7F45BD91CE4110B1BEAEFC1C0F6930532",
                                 "instructionPointer": 0,
-                                "nextInstruction": "55"
+                                "nextInstruction": "PUSHBYTES55"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES56.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES56.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x2FAD625E2DDED4BF26DF6A480ECD71247CAADCD7",
                                 "instructionPointer": 0,
-                                "nextInstruction": "56"
+                                "nextInstruction": "PUSHBYTES56"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES57.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES57.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x4CF3DD6291FFC12639BA33452D54C56D91DF900C",
                                 "instructionPointer": 0,
-                                "nextInstruction": "57"
+                                "nextInstruction": "PUSHBYTES57"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES58.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES58.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x9FAC0235F4F155EBB3ACA3A340D960C0D5658FB8",
                                 "instructionPointer": 0,
-                                "nextInstruction": "58"
+                                "nextInstruction": "PUSHBYTES58"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES59.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES59.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x5282E86B9AD6B9F094B39E099ED3818AA2AEDD83",
                                 "instructionPointer": 0,
-                                "nextInstruction": "59"
+                                "nextInstruction": "PUSHBYTES59"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES6.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES6.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xB58547C6C6EB3A94DCC4EF9BCD43192699B6755E",
                                 "instructionPointer": 0,
-                                "nextInstruction": "6"
+                                "nextInstruction": "PUSHBYTES6"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES60.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES60.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x1E327487E742D0DFE93E6A9497BDC3B6927C0BF0",
                                 "instructionPointer": 0,
-                                "nextInstruction": "60"
+                                "nextInstruction": "PUSHBYTES60"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES61.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES61.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xE7BEA1F43ADD0D079C47F24F2206C127C6F6372A",
                                 "instructionPointer": 0,
-                                "nextInstruction": "61"
+                                "nextInstruction": "PUSHBYTES61"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES62.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES62.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xCE9792912874EC25F00B3DF67ED11FF3A1A84271",
                                 "instructionPointer": 0,
-                                "nextInstruction": "62"
+                                "nextInstruction": "PUSHBYTES62"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES63.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES63.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x23570631BC21FD2CDD255B3561E415D55F4CCADC",
                                 "instructionPointer": 0,
-                                "nextInstruction": "63"
+                                "nextInstruction": "PUSHBYTES63"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES64.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES64.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x0BD6125B06687E78028F6C9631F02443D511DFC3",
                                 "instructionPointer": 0,
-                                "nextInstruction": "64"
+                                "nextInstruction": "PUSHBYTES64"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES65.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES65.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x6942C359B8CE9FCA0F5A432791303D35B8433ED0",
                                 "instructionPointer": 0,
-                                "nextInstruction": "65"
+                                "nextInstruction": "PUSHBYTES65"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES66.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES66.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xA680F10FAB82740A9FAA0CEB2742FC6BF5788BA2",
                                 "instructionPointer": 0,
-                                "nextInstruction": "66"
+                                "nextInstruction": "PUSHBYTES66"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES67.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES67.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x5722D91D45E47EB8B1F5F267A9641B0C4B693CA9",
                                 "instructionPointer": 0,
-                                "nextInstruction": "67"
+                                "nextInstruction": "PUSHBYTES67"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES68.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES68.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x459A0162BD0A48532DD8DBD08904E6385BE13323",
                                 "instructionPointer": 0,
-                                "nextInstruction": "68"
+                                "nextInstruction": "PUSHBYTES68"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES69.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES69.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x38CD55E334A2C26F220B09F7CF5CE7A16D32F61B",
                                 "instructionPointer": 0,
-                                "nextInstruction": "69"
+                                "nextInstruction": "PUSHBYTES69"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES7.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES7.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x0B579F80010C286BAAC0968123DC768D029A098D",
                                 "instructionPointer": 0,
-                                "nextInstruction": "7"
+                                "nextInstruction": "PUSHBYTES7"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES70.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES70.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x32A271D372EFBC01CC81C6A8133C5B3DE5B18F3C",
                                 "instructionPointer": 0,
-                                "nextInstruction": "70"
+                                "nextInstruction": "PUSHBYTES70"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES71.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES71.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x0FFF989F090D3E17F128AFB8DCB75E968B5D0779",
                                 "instructionPointer": 0,
-                                "nextInstruction": "71"
+                                "nextInstruction": "PUSHBYTES71"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES72.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES72.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x109C42291AA9E54CD4922A030B819FCB5512BE35",
                                 "instructionPointer": 0,
-                                "nextInstruction": "72"
+                                "nextInstruction": "PUSHBYTES72"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES73.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES73.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xCCE7CE2A40F823A697713D6461BFADBD718F74DE",
                                 "instructionPointer": 0,
-                                "nextInstruction": "73"
+                                "nextInstruction": "PUSHBYTES73"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES74.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES74.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x2BEA76697EDFEB62303797304D3584E079479F28",
                                 "instructionPointer": 0,
-                                "nextInstruction": "74"
+                                "nextInstruction": "PUSHBYTES74"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES8.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES8.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0xA7D14D1F8C02796ECF37C0E01C676955ECD5052F",
                                 "instructionPointer": 0,
-                                "nextInstruction": "8"
+                                "nextInstruction": "PUSHBYTES8"
                             }
                         ]
                     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES9.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES9.json
@@ -70,7 +70,7 @@
                             {
                                 "scriptHash": "0x23A7EC29015E1E30BC4F4D0DF512ECECBF091F08",
                                 "instructionPointer": 0,
-                                "nextInstruction": "9"
+                                "nextInstruction": "PUSHBYTES9"
                             }
                         ]
                     }


### PR DESCRIPTION
Currently the OpCodes PUSHBYTES2 - PUSHBYTES74 are auto generated based on continuous numbering. Because of that they do not have human readable names (e.g. when converting to strings). 

This results in:
- poorly readable test vectors, e.g:
https://github.com/neo-project/neo-vm/blob/937c0ffa204abed2dbd33ee084d42ba345b43526/tests/neo-vm.Tests/Tests/OpCodes/Push/PUSHBYTES10.json#L73
- violation of the (draft) test vector specification  (#94). Therefore adding unnecessary parsing logic for other languages that are also trying to adhere to these test vectors.

    The specification reads: 
    
    > ### nextInstruction
    > A String describing the human readable name of the next opcode to be executed. 
    > 
    >  This member is REQUIRED.

This PR addresses the issues by expanding the instructions.