### PR TITLE
try to fix bug 138

### DIFF
--- a/src/neo-vm/ExecutionContext.cs
+++ b/src/neo-vm/ExecutionContext.cs
@@ -62,7 +62,7 @@ namespace Neo.VM
             }
         }
 
-        public byte[] CallingScriptHash { get; }
+        public byte[] CallingScriptHash { get; set; }
 
         /// <summary>
         /// Constructor

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -331,7 +331,10 @@ namespace Neo.VM
                             if (context_new == null) return false;
                             context.EvaluationStack.CopyTo(context_new.EvaluationStack);
                             if (instruction.OpCode == OpCode.TAILCALL)
-                                InvocationStack.Remove(1);
+                            {
+                                ExecutionContext CallingContext = InvocationStack.Remove(1);
+                                CurrentContext.CallingScriptHash = CallingContext.CallingScriptHash;
+                            }
                             else
                                 context.EvaluationStack.Clear();
                             CheckStackSize(false, 0);
@@ -1211,7 +1214,10 @@ namespace Neo.VM
                             if (context_new == null) return false;
                             context.EvaluationStack.CopyTo(context_new.EvaluationStack, pcount);
                             if (instruction.OpCode == OpCode.CALL_ET || instruction.OpCode == OpCode.CALL_EDT)
-                                InvocationStack.Remove(1);
+                            {
+                                ExecutionContext CallingContext = InvocationStack.Remove(1);
+                                CurrentContext.CallingScriptHash = CallingContext.CallingScriptHash;
+                            }
                             else
                                 for (int i = 0; i < pcount; i++)
                                     context.EvaluationStack.Pop();


### PR DESCRIPTION
When `OpCode.CALL_ET` , `OpCode.CALL_ED` or `OpCode.TAILCAL` called, we also need  to update the `CallingScriptHash`,  as the calling context has been changed.