### PR TITLE
Renamed arrobas @ and format

### DIFF
--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -644,7 +644,7 @@ namespace Neo.VM
 
         //Reserved = 0xAC,
         //Reserved = 0xAE,
-        
+
         // Array
         /// <summary>
         /// An array is removed from top of the main stack. Its size is put on top of the main stack.

--- a/src/neo-vm/Script.cs
+++ b/src/neo-vm/Script.cs
@@ -56,6 +56,6 @@ namespace Neo.VM
             return instruction;
         }
 
-        public static implicit operator byte[](Script script) => script._value;
+        public static implicit operator byte[] (Script script) => script._value;
     }
 }

--- a/src/neo-vm/Types/InteropInterface.cs
+++ b/src/neo-vm/Types/InteropInterface.cs
@@ -42,9 +42,9 @@ namespace Neo.VM.Types
             return _object as I;
         }
 
-        public static implicit operator T(InteropInterface<T> @interface)
+        public static implicit operator T(InteropInterface<T> i)
         {
-            return @interface._object;
+            return i._object;
         }
     }
 }

--- a/src/neo-vm/Types/Struct.cs
+++ b/src/neo-vm/Types/Struct.cs
@@ -14,9 +14,9 @@ namespace Neo.VM.Types
 
         public Struct Clone()
         {
-            Struct @struct = new Struct();
+            Struct s = new Struct();
             Queue<Struct> queue = new Queue<Struct>();
-            queue.Enqueue(@struct);
+            queue.Enqueue(s);
             queue.Enqueue(this);
             while (queue.Count > 0)
             {
@@ -37,7 +37,7 @@ namespace Neo.VM.Types
                     }
                 }
             }
-            return @struct;
+            return s;
         }
 
         public override bool Equals(StackItem other)

--- a/tests/neo-vm.Tests/Types/VMUTStackItemType.cs
+++ b/tests/neo-vm.Tests/Types/VMUTStackItemType.cs
@@ -6,27 +6,27 @@
         /// Boolean (true,false)
         /// </summary>
         Boolean,
-        
+
         /// <summary>
         /// ByteArray
         /// </summary>
         ByteArray,
-        
+
         /// <summary>
         /// ByteArray as UTF8 string
         /// </summary>
         String,
-        
+
         /// <summary>
         /// String
         /// </summary>
         Interop,
-        
+
         /// <summary>
         /// BigInteger
         /// </summary>
         Integer,
-        
+
         /// <summary>
         /// Array
         /// </summary>

--- a/tests/neo-vm.Tests/UtDebugger.cs
+++ b/tests/neo-vm.Tests/UtDebugger.cs
@@ -61,11 +61,16 @@ namespace Neo.Test
             using (var engine = new ExecutionEngine())
             using (var script = new ScriptBuilder())
             {
-                /* ┌     */ script.EmitJump(OpCode.CALL, 5);
-                /* │  ┌> */ script.Emit(OpCode.NOT);
-                /* │  │  */ script.Emit(OpCode.RET);
-                /* └> │  */ script.Emit(OpCode.PUSH0);
-                /*  └─┘  */ script.Emit(OpCode.RET);
+                /* ┌     CALL  */
+                /* │  ┌> NOT   */
+                /* │  │  RET   */
+                /* └> │  PUSH0 */
+                /*  └─┘  RET   */
+                script.EmitJump(OpCode.CALL, 5);
+                script.Emit(OpCode.NOT);
+                script.Emit(OpCode.RET);
+                script.Emit(OpCode.PUSH0);
+                script.Emit(OpCode.RET);
 
                 engine.LoadScript(script.ToArray());
 
@@ -89,11 +94,16 @@ namespace Neo.Test
             using (var engine = new ExecutionEngine())
             using (var script = new ScriptBuilder())
             {
-                /* ┌     */ script.EmitJump(OpCode.CALL, 5);
-                /* │  ┌> */ script.Emit(OpCode.NOT);
-                /* │  │  */ script.Emit(OpCode.RET);
-                /* └> │  */ script.Emit(OpCode.PUSH0);
-                /*  └─┘  */ script.Emit(OpCode.RET);
+                /* ┌     CALL  */
+                /* │  ┌> NOT   */
+                /* │  │  RET   */
+                /* └> │  PUSH0 */
+                /*  └─┘  RET   */
+                script.EmitJump(OpCode.CALL, 5);
+                script.Emit(OpCode.NOT);
+                script.Emit(OpCode.RET);
+                script.Emit(OpCode.PUSH0);
+                script.Emit(OpCode.RET);
 
                 engine.LoadScript(script.ToArray());
 
@@ -129,11 +139,16 @@ namespace Neo.Test
             using (var engine = new ExecutionEngine())
             using (var script = new ScriptBuilder())
             {
-                /* ┌     */ script.EmitJump(OpCode.CALL, 5);
-                /* │  ┌> */ script.Emit(OpCode.NOT);
-                /* │  │  */ script.Emit(OpCode.RET);
-                /* └>X│  */ script.Emit(OpCode.PUSH0);
-                /*   └┘  */ script.Emit(OpCode.RET);
+                /* ┌     CALL  */
+                /* │  ┌> NOT   */
+                /* │  │  RET   */
+                /* └>X│  PUSH0 */
+                /*   └┘  RET   */
+                script.EmitJump(OpCode.CALL, 5);
+                script.Emit(OpCode.NOT);
+                script.Emit(OpCode.RET);
+                script.Emit(OpCode.PUSH0);
+                script.Emit(OpCode.RET);
 
                 engine.LoadScript(script.ToArray());
 

--- a/tests/neo-vm.Tests/UtStruct.cs
+++ b/tests/neo-vm.Tests/UtStruct.cs
@@ -6,13 +6,13 @@ namespace Neo.Test
     [TestClass]
     public class UtStruct
     {
-        private readonly Struct s;
+        private readonly Struct uut;
 
         public UtStruct()
         {
-            s = new Struct { 1 };
+            uut = new Struct { 1 };
             for (int i = 0; i < 20000; i++)
-                s = new Struct { s };
+                uut = new Struct { uut };
         }
 
         [TestMethod]
@@ -24,7 +24,7 @@ namespace Neo.Test
             Assert.AreEqual(1, s2[0]);
             ((Struct)s1[1])[0] = 3;
             Assert.AreEqual(2, ((Struct)s2[1])[0]);
-            s.Clone();
+            uut.Clone();
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace Neo.Test
             Assert.IsTrue(s1.Equals(s2));
             Struct s3 = new Struct { 1, new Struct { 3 } };
             Assert.IsFalse(s1.Equals(s3));
-            Assert.IsTrue(s.Equals(s.Clone()));
+            Assert.IsTrue(uut.Equals(uut.Clone()));
         }
     }
 }

--- a/tests/neo-vm.Tests/UtStruct.cs
+++ b/tests/neo-vm.Tests/UtStruct.cs
@@ -6,13 +6,13 @@ namespace Neo.Test
     [TestClass]
     public class UtStruct
     {
-        private readonly Struct @struct;
+        private readonly Struct s;
 
         public UtStruct()
         {
-            @struct = new Struct { 1 };
+            s = new Struct { 1 };
             for (int i = 0; i < 20000; i++)
-                @struct = new Struct { @struct };
+                s = new Struct { s };
         }
 
         [TestMethod]
@@ -24,7 +24,7 @@ namespace Neo.Test
             Assert.AreEqual(1, s2[0]);
             ((Struct)s1[1])[0] = 3;
             Assert.AreEqual(2, ((Struct)s2[1])[0]);
-            @struct.Clone();
+            s.Clone();
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace Neo.Test
             Assert.IsTrue(s1.Equals(s2));
             Struct s3 = new Struct { 1, new Struct { 3 } };
             Assert.IsFalse(s1.Equals(s3));
-            Assert.IsTrue(@struct.Equals(@struct.Clone()));
+            Assert.IsTrue(s.Equals(s.Clone()));
         }
     }
 }


### PR DESCRIPTION
This symbol @ on a variable took me months of headaches, because I thought it was an special operator of C#... just now I again, after struggling with it, realized it's a way to give the actual reserved name to a variable. 
Please, let's remove this. I know this is easy for C# coders, but for everyone else, like me, it can cause several understanding problems (not now, obviously, that I learned it, but it took time...). This is only recommended when linking against another dynamic library with a given specific name (when you really cannot change the name...), which is not the case for local variables.

@shargon I applied the formatter, and it was destroying your sketches, so I re-drew them in a similar manner, now resistant to formatters ;) Now I could apply `dotnet format`.