### PR TITLE
TryPop

### DIFF
--- a/src/neo-vm/ExecutionContext.cs
+++ b/src/neo-vm/ExecutionContext.cs
@@ -1,3 +1,4 @@
+using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1135,8 +1135,8 @@ namespace Neo.VM
                         }
                     case OpCode.KEYS:
                         {
-                            if (!context.EvaluationStack.TryPop<Map>(out var map))
-                                context.EvaluationStack.Push(new VMArray(map.Keys));
+                            if (!context.EvaluationStack.TryPop<Map>(out var map)) return false;
+                            context.EvaluationStack.Push(new VMArray(map.Keys));
                             if (!CheckStackSize(false, map.Count)) return false;
                             break;
                         }

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -345,7 +345,7 @@ namespace Neo.VM
                         }
                     case OpCode.XDROP:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_n))
                                 return false;
                             int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
@@ -355,7 +355,7 @@ namespace Neo.VM
                         }
                     case OpCode.XSWAP:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_n))
                                 return false;
                             int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
@@ -368,7 +368,7 @@ namespace Neo.VM
                         }
                     case OpCode.XTUCK:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_n))
                                 return false;
                             int n = (int)item_n.ToBigInteger();
                             if (n <= 0) return false;
@@ -407,7 +407,7 @@ namespace Neo.VM
                         }
                     case OpCode.PICK:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_n))
                                 return false;
                             int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
@@ -416,7 +416,7 @@ namespace Neo.VM
                         }
                     case OpCode.ROLL:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_n))
                                 return false;
                             int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
@@ -443,10 +443,10 @@ namespace Neo.VM
                         }
                     case OpCode.CAT:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             ReadOnlyMemory<byte> x2 = item_x2.ToMemory();
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             ReadOnlyMemory<byte> x1 = item_x1.ToMemory();
                             StackItem result;
@@ -473,16 +473,16 @@ namespace Neo.VM
                         }
                     case OpCode.SUBSTR:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_count))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_count))
                                 return false;
                             int count = (int)item_count.ToBigInteger();
                             if (count < 0) return false;
                             if (count > MaxItemSize) count = (int)MaxItemSize;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_index))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_index))
                                 return false;
                             int index = (int)item_index.ToBigInteger();
                             if (index < 0) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             ReadOnlyMemory<byte> x = item_x.ToMemory();
                             if (index > x.Length) return false;
@@ -493,11 +493,11 @@ namespace Neo.VM
                         }
                     case OpCode.LEFT:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_count))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_count))
                                 return false;
                             int count = (int)item_count.ToBigInteger();
                             if (count < 0) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             ReadOnlyMemory<byte> x = item_x.ToMemory();
                             if (count < x.Length)
@@ -508,11 +508,11 @@ namespace Neo.VM
                         }
                     case OpCode.RIGHT:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_count))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_count))
                                 return false;
                             int count = (int)item_count.ToBigInteger();
                             if (count < 0) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             ReadOnlyMemory<byte> x = item_x.ToMemory();
                             if (count > x.Length) return false;
@@ -524,7 +524,7 @@ namespace Neo.VM
                         }
                     case OpCode.SIZE:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var x))
                                 return false;
                             context.EvaluationStack.Push(x.GetByteLength());
                             break;
@@ -533,7 +533,7 @@ namespace Neo.VM
                     // Bitwise logic
                     case OpCode.INVERT:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -542,11 +542,11 @@ namespace Neo.VM
                         }
                     case OpCode.AND:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -556,11 +556,11 @@ namespace Neo.VM
                         }
                     case OpCode.OR:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -570,11 +570,11 @@ namespace Neo.VM
                         }
                     case OpCode.XOR:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -594,7 +594,7 @@ namespace Neo.VM
                     // Numeric
                     case OpCode.INC:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -605,7 +605,7 @@ namespace Neo.VM
                         }
                     case OpCode.DEC:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -616,7 +616,7 @@ namespace Neo.VM
                         }
                     case OpCode.SIGN:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -625,7 +625,7 @@ namespace Neo.VM
                         }
                     case OpCode.NEGATE:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -634,7 +634,7 @@ namespace Neo.VM
                         }
                     case OpCode.ABS:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -650,7 +650,7 @@ namespace Neo.VM
                         }
                     case OpCode.NZ:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -659,11 +659,11 @@ namespace Neo.VM
                         }
                     case OpCode.ADD:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -675,11 +675,11 @@ namespace Neo.VM
                         }
                     case OpCode.SUB:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -691,11 +691,11 @@ namespace Neo.VM
                         }
                     case OpCode.MUL:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -707,11 +707,11 @@ namespace Neo.VM
                         }
                     case OpCode.DIV:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -721,11 +721,11 @@ namespace Neo.VM
                         }
                     case OpCode.MOD:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -735,13 +735,13 @@ namespace Neo.VM
                         }
                     case OpCode.SHL:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_shift))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_shift))
                                 return false;
                             int shift = (int)item_shift.ToBigInteger();
                             CheckStackSize(true, -1);
                             if (!CheckShift(shift)) return false;
                             if (shift == 0) break;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -752,13 +752,13 @@ namespace Neo.VM
                         }
                     case OpCode.SHR:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_shift))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_shift))
                                 return false;
                             int shift = (int)item_shift.ToBigInteger();
                             CheckStackSize(true, -1);
                             if (!CheckShift(shift)) return false;
                             if (shift == 0) break;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -785,11 +785,11 @@ namespace Neo.VM
                         }
                     case OpCode.NUMEQUAL:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -799,11 +799,11 @@ namespace Neo.VM
                         }
                     case OpCode.NUMNOTEQUAL:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -813,11 +813,11 @@ namespace Neo.VM
                         }
                     case OpCode.LT:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -827,11 +827,11 @@ namespace Neo.VM
                         }
                     case OpCode.GT:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -841,11 +841,11 @@ namespace Neo.VM
                         }
                     case OpCode.LTE:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -855,11 +855,11 @@ namespace Neo.VM
                         }
                     case OpCode.GTE:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -869,11 +869,11 @@ namespace Neo.VM
                         }
                     case OpCode.MIN:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -883,11 +883,11 @@ namespace Neo.VM
                         }
                     case OpCode.MAX:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x2))
                                 return false;
                             BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x1))
                                 return false;
                             BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
@@ -897,15 +897,15 @@ namespace Neo.VM
                         }
                     case OpCode.WITHIN:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_b))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_b))
                                 return false;
                             BigInteger b = item_b.ToBigInteger();
                             if (!CheckBigInteger(b)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_a))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_a))
                                 return false;
                             BigInteger a = item_a.ToBigInteger();
                             if (!CheckBigInteger(a)) return false;
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_x))
                                 return false;
                             BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
@@ -934,7 +934,7 @@ namespace Neo.VM
                         }
                     case OpCode.PACK:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_size))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var item_size))
                                 return false;
                             int size = (int)item_size.ToBigInteger();
                             if (size < 0 || size > context.EvaluationStack.Count || !CheckArraySize(size))
@@ -947,7 +947,7 @@ namespace Neo.VM
                         }
                     case OpCode.UNPACK:
                         {
-                            if (!(context.EvaluationStack.Pop() is VMArray array))
+                            if (!context.EvaluationStack.TryPop<VMArray>(out var array))
                                 return false;
                             for (int i = array.Count - 1; i >= 0; i--)
                                 context.EvaluationStack.Push(array[i]);
@@ -957,7 +957,7 @@ namespace Neo.VM
                         }
                     case OpCode.PICKITEM:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var key))
                                 return false;
                             switch (context.EvaluationStack.Pop())
                             {
@@ -994,7 +994,7 @@ namespace Neo.VM
                         {
                             StackItem value = context.EvaluationStack.Pop();
                             if (value is Struct s) value = s.Clone();
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var key))
                                 return false;
                             switch (context.EvaluationStack.Pop())
                             {
@@ -1092,7 +1092,7 @@ namespace Neo.VM
                         }
                     case OpCode.REMOVE:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var key))
                                 return false;
                             StackItem value = context.EvaluationStack.Pop();
                             CheckStackSize(false, -2);
@@ -1115,7 +1115,7 @@ namespace Neo.VM
                         }
                     case OpCode.HASKEY:
                         {
-                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                            if (!context.EvaluationStack.TryPop<PrimitiveType>(out var key))
                                 return false;
                             switch (context.EvaluationStack.Pop())
                             {
@@ -1135,8 +1135,8 @@ namespace Neo.VM
                         }
                     case OpCode.KEYS:
                         {
-                            if (!(context.EvaluationStack.Pop() is Map map)) return false;
-                            context.EvaluationStack.Push(new VMArray(map.Keys));
+                            if (!context.EvaluationStack.TryPop<Map>(out var map))
+                                context.EvaluationStack.Push(new VMArray(map.Keys));
                             if (!CheckStackSize(false, map.Count)) return false;
                             break;
                         }

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1,6 +1,5 @@
 using Neo.VM.Types;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -260,7 +259,7 @@ namespace Neo.VM
                             if (instruction.OpCode > OpCode.JMP)
                             {
                                 CheckStackSize(false, -1);
-                                fValue = context.EvaluationStack.Pop().GetBoolean();
+                                fValue = context.EvaluationStack.Pop().ToBoolean();
 
                                 if (instruction.OpCode == OpCode.JMPIFNOT)
                                     fValue = !fValue;
@@ -346,7 +345,9 @@ namespace Neo.VM
                         }
                     case OpCode.XDROP:
                         {
-                            int n = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                                return false;
+                            int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
                             context.EvaluationStack.Remove(n);
                             CheckStackSize(false, -2);
@@ -354,7 +355,9 @@ namespace Neo.VM
                         }
                     case OpCode.XSWAP:
                         {
-                            int n = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                                return false;
+                            int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
                             CheckStackSize(true, -1);
                             if (n == 0) break;
@@ -365,7 +368,9 @@ namespace Neo.VM
                         }
                     case OpCode.XTUCK:
                         {
-                            int n = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                                return false;
+                            int n = (int)item_n.ToBigInteger();
                             if (n <= 0) return false;
                             context.EvaluationStack.Insert(n, context.EvaluationStack.Peek());
                             break;
@@ -402,14 +407,18 @@ namespace Neo.VM
                         }
                     case OpCode.PICK:
                         {
-                            int n = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                                return false;
+                            int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
                             context.EvaluationStack.Push(context.EvaluationStack.Peek(n));
                             break;
                         }
                     case OpCode.ROLL:
                         {
-                            int n = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_n))
+                                return false;
+                            int n = (int)item_n.ToBigInteger();
                             if (n < 0) return false;
                             CheckStackSize(true, -1);
                             if (n == 0) break;
@@ -434,8 +443,12 @@ namespace Neo.VM
                         }
                     case OpCode.CAT:
                         {
-                            ReadOnlyMemory<byte> x2 = context.EvaluationStack.Pop().ToMemory();
-                            ReadOnlyMemory<byte> x1 = context.EvaluationStack.Pop().ToMemory();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            ReadOnlyMemory<byte> x2 = item_x2.ToMemory();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            ReadOnlyMemory<byte> x1 = item_x1.ToMemory();
                             StackItem result;
                             if (x1.IsEmpty)
                             {
@@ -460,12 +473,18 @@ namespace Neo.VM
                         }
                     case OpCode.SUBSTR:
                         {
-                            int count = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_count))
+                                return false;
+                            int count = (int)item_count.ToBigInteger();
                             if (count < 0) return false;
                             if (count > MaxItemSize) count = (int)MaxItemSize;
-                            int index = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_index))
+                                return false;
+                            int index = (int)item_index.ToBigInteger();
                             if (index < 0) return false;
-                            ReadOnlyMemory<byte> x = context.EvaluationStack.Pop().ToMemory();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            ReadOnlyMemory<byte> x = item_x.ToMemory();
                             if (index > x.Length) return false;
                             if (index + count > x.Length) count = x.Length - index;
                             context.EvaluationStack.Push(x.Slice(index, count));
@@ -474,9 +493,13 @@ namespace Neo.VM
                         }
                     case OpCode.LEFT:
                         {
-                            int count = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_count))
+                                return false;
+                            int count = (int)item_count.ToBigInteger();
                             if (count < 0) return false;
-                            ReadOnlyMemory<byte> x = context.EvaluationStack.Pop().ToMemory();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            ReadOnlyMemory<byte> x = item_x.ToMemory();
                             if (count < x.Length)
                                 x = x[0..count];
                             context.EvaluationStack.Push(x);
@@ -485,9 +508,13 @@ namespace Neo.VM
                         }
                     case OpCode.RIGHT:
                         {
-                            int count = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_count))
+                                return false;
+                            int count = (int)item_count.ToBigInteger();
                             if (count < 0) return false;
-                            ReadOnlyMemory<byte> x = context.EvaluationStack.Pop().ToMemory();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            ReadOnlyMemory<byte> x = item_x.ToMemory();
                             if (count > x.Length) return false;
                             if (count < x.Length)
                                 x = x[^count..^0];
@@ -497,7 +524,8 @@ namespace Neo.VM
                         }
                     case OpCode.SIZE:
                         {
-                            StackItem x = context.EvaluationStack.Pop();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType x))
+                                return false;
                             context.EvaluationStack.Push(x.GetByteLength());
                             break;
                         }
@@ -505,16 +533,22 @@ namespace Neo.VM
                     // Bitwise logic
                     case OpCode.INVERT:
                         {
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(~x);
                             break;
                         }
                     case OpCode.AND:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 & x2);
                             CheckStackSize(true, -1);
@@ -522,9 +556,13 @@ namespace Neo.VM
                         }
                     case OpCode.OR:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 | x2);
                             CheckStackSize(true, -1);
@@ -532,9 +570,13 @@ namespace Neo.VM
                         }
                     case OpCode.XOR:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 ^ x2);
                             CheckStackSize(true, -1);
@@ -552,7 +594,9 @@ namespace Neo.VM
                     // Numeric
                     case OpCode.INC:
                         {
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             x += 1;
                             if (!CheckBigInteger(x)) return false;
@@ -561,7 +605,9 @@ namespace Neo.VM
                         }
                     case OpCode.DEC:
                         {
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             x -= 1;
                             if (!CheckBigInteger(x)) return false;
@@ -570,44 +616,56 @@ namespace Neo.VM
                         }
                     case OpCode.SIGN:
                         {
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(x.Sign);
                             break;
                         }
                     case OpCode.NEGATE:
                         {
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(-x);
                             break;
                         }
                     case OpCode.ABS:
                         {
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(BigInteger.Abs(x));
                             break;
                         }
                     case OpCode.NOT:
                         {
-                            bool x = context.EvaluationStack.Pop().GetBoolean();
+                            bool x = context.EvaluationStack.Pop().ToBoolean();
                             context.EvaluationStack.Push(!x);
                             CheckStackSize(false, 0);
                             break;
                         }
                     case OpCode.NZ:
                         {
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(!x.IsZero);
                             break;
                         }
                     case OpCode.ADD:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             BigInteger result = x1 + x2;
                             if (!CheckBigInteger(result)) return false;
@@ -617,9 +675,13 @@ namespace Neo.VM
                         }
                     case OpCode.SUB:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             BigInteger result = x1 - x2;
                             if (!CheckBigInteger(result)) return false;
@@ -629,9 +691,13 @@ namespace Neo.VM
                         }
                     case OpCode.MUL:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             BigInteger result = x1 * x2;
                             if (!CheckBigInteger(result)) return false;
@@ -641,9 +707,13 @@ namespace Neo.VM
                         }
                     case OpCode.DIV:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 / x2);
                             CheckStackSize(true, -1);
@@ -651,9 +721,13 @@ namespace Neo.VM
                         }
                     case OpCode.MOD:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 % x2);
                             CheckStackSize(true, -1);
@@ -661,11 +735,15 @@ namespace Neo.VM
                         }
                     case OpCode.SHL:
                         {
-                            int shift = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_shift))
+                                return false;
+                            int shift = (int)item_shift.ToBigInteger();
                             CheckStackSize(true, -1);
                             if (!CheckShift(shift)) return false;
                             if (shift == 0) break;
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             x <<= shift;
                             if (!CheckBigInteger(x)) return false;
@@ -674,11 +752,15 @@ namespace Neo.VM
                         }
                     case OpCode.SHR:
                         {
-                            int shift = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_shift))
+                                return false;
+                            int shift = (int)item_shift.ToBigInteger();
                             CheckStackSize(true, -1);
                             if (!CheckShift(shift)) return false;
                             if (shift == 0) break;
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             x >>= shift;
                             if (!CheckBigInteger(x)) return false;
@@ -687,25 +769,29 @@ namespace Neo.VM
                         }
                     case OpCode.BOOLAND:
                         {
-                            bool x2 = context.EvaluationStack.Pop().GetBoolean();
-                            bool x1 = context.EvaluationStack.Pop().GetBoolean();
+                            bool x2 = context.EvaluationStack.Pop().ToBoolean();
+                            bool x1 = context.EvaluationStack.Pop().ToBoolean();
                             context.EvaluationStack.Push(x1 && x2);
                             CheckStackSize(false, -1);
                             break;
                         }
                     case OpCode.BOOLOR:
                         {
-                            bool x2 = context.EvaluationStack.Pop().GetBoolean();
-                            bool x1 = context.EvaluationStack.Pop().GetBoolean();
+                            bool x2 = context.EvaluationStack.Pop().ToBoolean();
+                            bool x1 = context.EvaluationStack.Pop().ToBoolean();
                             context.EvaluationStack.Push(x1 || x2);
                             CheckStackSize(false, -1);
                             break;
                         }
                     case OpCode.NUMEQUAL:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 == x2);
                             CheckStackSize(true, -1);
@@ -713,9 +799,13 @@ namespace Neo.VM
                         }
                     case OpCode.NUMNOTEQUAL:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 != x2);
                             CheckStackSize(true, -1);
@@ -723,9 +813,13 @@ namespace Neo.VM
                         }
                     case OpCode.LT:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 < x2);
                             CheckStackSize(true, -1);
@@ -733,9 +827,13 @@ namespace Neo.VM
                         }
                     case OpCode.GT:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 > x2);
                             CheckStackSize(true, -1);
@@ -743,9 +841,13 @@ namespace Neo.VM
                         }
                     case OpCode.LTE:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 <= x2);
                             CheckStackSize(true, -1);
@@ -753,9 +855,13 @@ namespace Neo.VM
                         }
                     case OpCode.GTE:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(x1 >= x2);
                             CheckStackSize(true, -1);
@@ -763,9 +869,13 @@ namespace Neo.VM
                         }
                     case OpCode.MIN:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(BigInteger.Min(x1, x2));
                             CheckStackSize(true, -1);
@@ -773,9 +883,13 @@ namespace Neo.VM
                         }
                     case OpCode.MAX:
                         {
-                            BigInteger x2 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x2))
+                                return false;
+                            BigInteger x2 = item_x2.ToBigInteger();
                             if (!CheckBigInteger(x2)) return false;
-                            BigInteger x1 = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x1))
+                                return false;
+                            BigInteger x1 = item_x1.ToBigInteger();
                             if (!CheckBigInteger(x1)) return false;
                             context.EvaluationStack.Push(BigInteger.Max(x1, x2));
                             CheckStackSize(true, -1);
@@ -783,11 +897,17 @@ namespace Neo.VM
                         }
                     case OpCode.WITHIN:
                         {
-                            BigInteger b = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_b))
+                                return false;
+                            BigInteger b = item_b.ToBigInteger();
                             if (!CheckBigInteger(b)) return false;
-                            BigInteger a = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_a))
+                                return false;
+                            BigInteger a = item_a.ToBigInteger();
                             if (!CheckBigInteger(a)) return false;
-                            BigInteger x = context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_x))
+                                return false;
+                            BigInteger x = item_x.ToBigInteger();
                             if (!CheckBigInteger(x)) return false;
                             context.EvaluationStack.Push(a <= x && x < b);
                             CheckStackSize(true, -2);
@@ -797,22 +917,26 @@ namespace Neo.VM
                     // Array
                     case OpCode.ARRAYSIZE:
                         {
-                            StackItem item = context.EvaluationStack.Pop();
-                            if (item is ICollection collection)
+                            switch (context.EvaluationStack.Pop())
                             {
-                                context.EvaluationStack.Push(collection.Count);
-                                CheckStackSize(false, 0);
-                            }
-                            else
-                            {
-                                context.EvaluationStack.Push(item.GetByteLength());
-                                CheckStackSize(true, 0);
+                                case CompoundType compound:
+                                    context.EvaluationStack.Push(compound.Count);
+                                    CheckStackSize(false, 0);
+                                    break;
+                                case PrimitiveType primitive:
+                                    context.EvaluationStack.Push(primitive.GetByteLength());
+                                    CheckStackSize(true, 0);
+                                    break;
+                                default:
+                                    return false;
                             }
                             break;
                         }
                     case OpCode.PACK:
                         {
-                            int size = (int)context.EvaluationStack.Pop().GetBigInteger();
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType item_size))
+                                return false;
+                            int size = (int)item_size.ToBigInteger();
                             if (size < 0 || size > context.EvaluationStack.Count || !CheckArraySize(size))
                                 return false;
                             List<StackItem> items = new List<StackItem>(size);
@@ -833,14 +957,13 @@ namespace Neo.VM
                         }
                     case OpCode.PICKITEM:
                         {
-                            StackItem key = context.EvaluationStack.Pop();
-                            if (key is ICollection) return false;
-                            StackItem item = context.EvaluationStack.Pop();
-                            switch (item)
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                                return false;
+                            switch (context.EvaluationStack.Pop())
                             {
                                 case VMArray array:
                                     {
-                                        int index = (int)key.GetBigInteger();
+                                        int index = (int)key.ToBigInteger();
                                         if (index < 0 || index >= array.Count) return false;
                                         context.EvaluationStack.Push(array[index]);
                                         CheckStackSize(false, -1);
@@ -853,15 +976,17 @@ namespace Neo.VM
                                         CheckStackSize(false, -1);
                                         break;
                                     }
-                                default:
+                                case PrimitiveType primitive:
                                     {
-                                        ReadOnlySpan<byte> byteArray = item.GetByteArray();
-                                        int index = (int)key.GetBigInteger();
+                                        ReadOnlySpan<byte> byteArray = primitive.ToByteArray();
+                                        int index = (int)key.ToBigInteger();
                                         if (index < 0 || index >= byteArray.Length) return false;
                                         context.EvaluationStack.Push((int)byteArray[index]);
                                         CheckStackSize(true, -1);
                                         break;
                                     }
+                                default:
+                                    return false;
                             }
                             break;
                         }
@@ -869,13 +994,13 @@ namespace Neo.VM
                         {
                             StackItem value = context.EvaluationStack.Pop();
                             if (value is Struct s) value = s.Clone();
-                            StackItem key = context.EvaluationStack.Pop();
-                            if (key is ICollection) return false;
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                                return false;
                             switch (context.EvaluationStack.Pop())
                             {
                                 case VMArray array:
                                     {
-                                        int index = (int)key.GetBigInteger();
+                                        int index = (int)key.ToBigInteger();
                                         if (index < 0 || index >= array.Count) return false;
                                         array[index] = value;
                                         break;
@@ -899,49 +1024,44 @@ namespace Neo.VM
                     case OpCode.NEWARRAY:
                     case OpCode.NEWSTRUCT:
                         {
-                            var item = context.EvaluationStack.Peek();
-
-                            if (item is VMArray array)
+                            switch (context.EvaluationStack.Peek())
                             {
-                                // Allow to convert between array and struct
-
-                                if (array is Struct)
-                                {
-                                    if (instruction.OpCode == OpCode.NEWSTRUCT)
-                                        break;
-                                }
-                                else
-                                {
-                                    if (instruction.OpCode == OpCode.NEWARRAY)
-                                        break;
-                                }
-
-                                VMArray result = instruction.OpCode == OpCode.NEWARRAY
-                                    ? new VMArray(array)
-                                    : new Struct(array);
-
-                                context.EvaluationStack.Set(0, result);
-                                if (!CheckStackSize(false, int.MaxValue)) return false;
-                            }
-                            else
-                            {
-                                int count = (int)item.GetBigInteger();
-
-                                if (count < 0 || !CheckArraySize(count)) return false;
-
-                                List<StackItem> items = new List<StackItem>(count);
-
-                                for (var i = 0; i < count; i++)
-                                {
-                                    items.Add(false);
-                                }
-
-                                VMArray result = instruction.OpCode == OpCode.NEWARRAY
-                                    ? new VMArray(items)
-                                    : new Struct(items);
-
-                                context.EvaluationStack.Set(0, result);
-                                if (!CheckStackSize(true, count)) return false;
+                                case VMArray array:
+                                    {
+                                        // Allow to convert between array and struct
+                                        if (array is Struct)
+                                        {
+                                            if (instruction.OpCode == OpCode.NEWSTRUCT)
+                                                break;
+                                        }
+                                        else
+                                        {
+                                            if (instruction.OpCode == OpCode.NEWARRAY)
+                                                break;
+                                        }
+                                        VMArray result = instruction.OpCode == OpCode.NEWARRAY
+                                            ? new VMArray(array)
+                                            : new Struct(array);
+                                        context.EvaluationStack.Set(0, result);
+                                        if (!CheckStackSize(false, int.MaxValue)) return false;
+                                    }
+                                    break;
+                                case PrimitiveType primitive:
+                                    {
+                                        int count = (int)primitive.ToBigInteger();
+                                        if (count < 0 || !CheckArraySize(count)) return false;
+                                        List<StackItem> items = new List<StackItem>(count);
+                                        for (var i = 0; i < count; i++)
+                                            items.Add(false);
+                                        VMArray result = instruction.OpCode == OpCode.NEWARRAY
+                                            ? new VMArray(items)
+                                            : new Struct(items);
+                                        context.EvaluationStack.Set(0, result);
+                                        if (!CheckStackSize(true, count)) return false;
+                                    }
+                                    break;
+                                default:
+                                    return false;
                             }
                             break;
                         }
@@ -972,14 +1092,14 @@ namespace Neo.VM
                         }
                     case OpCode.REMOVE:
                         {
-                            StackItem key = context.EvaluationStack.Pop();
-                            if (key is ICollection) return false;
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                                return false;
                             StackItem value = context.EvaluationStack.Pop();
                             CheckStackSize(false, -2);
                             switch (value)
                             {
                                 case VMArray array:
-                                    int index = (int)key.GetBigInteger();
+                                    int index = (int)key.ToBigInteger();
                                     if (index < 0 || index >= array.Count) return false;
                                     array.RemoveAt(index);
                                     CheckStackSize(false, -1);
@@ -995,12 +1115,12 @@ namespace Neo.VM
                         }
                     case OpCode.HASKEY:
                         {
-                            StackItem key = context.EvaluationStack.Pop();
-                            if (key is ICollection) return false;
+                            if (!(context.EvaluationStack.Pop() is PrimitiveType key))
+                                return false;
                             switch (context.EvaluationStack.Pop())
                             {
                                 case VMArray array:
-                                    int index = (int)key.GetBigInteger();
+                                    int index = (int)key.ToBigInteger();
                                     if (index < 0) return false;
                                     context.EvaluationStack.Push(index < array.Count);
                                     break;
@@ -1052,7 +1172,7 @@ namespace Neo.VM
                         }
                     case OpCode.THROWIFNOT:
                         {
-                            if (!context.EvaluationStack.Pop().GetBoolean())
+                            if (!context.EvaluationStack.Pop().ToBoolean())
                                 return false;
                             CheckStackSize(false, -1);
                             break;

--- a/src/neo-vm/RandomAccessStack.cs
+++ b/src/neo-vm/RandomAccessStack.cs
@@ -64,6 +64,26 @@ namespace Neo.VM
             return Remove(0);
         }
 
+        public bool TryPop<TItem>(out TItem item)
+        {
+            var index = list.Count - 1;
+
+            if (index >= 0)
+            {
+                var entry = list[index];
+                list.RemoveAt(index);
+
+                if (entry is TItem i)
+                {
+                    item = i;
+                    return true;
+                }
+            }
+
+            item = default;
+            return false;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Push(T item)
         {

--- a/src/neo-vm/Types/Array.cs
+++ b/src/neo-vm/Types/Array.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,7 +6,7 @@ using System.Linq;
 namespace Neo.VM.Types
 {
     [DebuggerDisplay("Type={GetType().Name}, Count={Count}")]
-    public class Array : StackItem, ICollection, IList<StackItem>
+    public class Array : CompoundType, IList<StackItem>
     {
         protected readonly List<StackItem> _array;
 
@@ -17,11 +16,8 @@ namespace Neo.VM.Types
             set => _array[index] = value;
         }
 
-        public int Count => _array.Count;
+        public override int Count => _array.Count;
         public bool IsReadOnly => false;
-
-        bool ICollection.IsSynchronized => false;
-        object ICollection.SyncRoot => _array;
 
         public Array() : this(new List<StackItem>()) { }
 
@@ -35,7 +31,7 @@ namespace Neo.VM.Types
             _array.Add(item);
         }
 
-        public void Clear()
+        public override void Clear()
         {
             _array.Clear();
         }
@@ -48,27 +44,6 @@ namespace Neo.VM.Types
         void ICollection<StackItem>.CopyTo(StackItem[] array, int arrayIndex)
         {
             _array.CopyTo(array, arrayIndex);
-        }
-
-        void ICollection.CopyTo(System.Array array, int index)
-        {
-            foreach (StackItem item in _array)
-                array.SetValue(item, index++);
-        }
-
-        public override bool Equals(StackItem other)
-        {
-            return ReferenceEquals(this, other);
-        }
-
-        public override bool GetBoolean()
-        {
-            return true;
-        }
-
-        public override ReadOnlySpan<byte> GetByteArray()
-        {
-            throw new NotSupportedException();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -104,11 +79,6 @@ namespace Neo.VM.Types
         public void Reverse()
         {
             _array.Reverse();
-        }
-
-        internal override ReadOnlyMemory<byte> ToMemory()
-        {
-            throw new NotSupportedException();
         }
     }
 }

--- a/src/neo-vm/Types/Boolean.cs
+++ b/src/neo-vm/Types/Boolean.cs
@@ -5,7 +5,7 @@ using System.Numerics;
 namespace Neo.VM.Types
 {
     [DebuggerDisplay("Type={GetType().Name}, Value={value}")]
-    public class Boolean : StackItem
+    public class Boolean : PrimitiveType
     {
         private static readonly byte[] TRUE = new byte[] { 1 };
         private static readonly byte[] FALSE = new byte[] { 0 };
@@ -22,31 +22,22 @@ namespace Neo.VM.Types
             if (ReferenceEquals(this, other)) return true;
             if (other is null) return false;
             if (other is Boolean b) return value == b.value;
-            ReadOnlySpan<byte> bytes_other;
-            try
-            {
-                bytes_other = other.GetByteArray();
-            }
-            catch (NotSupportedException)
-            {
-                return false;
-            }
-            return Unsafe.MemoryEquals(GetByteArray(), bytes_other);
+            return base.Equals(other);
         }
 
-        public override BigInteger GetBigInteger()
+        public override int GetByteLength()
+        {
+            return sizeof(bool);
+        }
+
+        public override BigInteger ToBigInteger()
         {
             return value ? BigInteger.One : BigInteger.Zero;
         }
 
-        public override bool GetBoolean()
+        public override bool ToBoolean()
         {
             return value;
-        }
-
-        public override ReadOnlySpan<byte> GetByteArray()
-        {
-            return value ? TRUE : FALSE;
         }
 
         internal override ReadOnlyMemory<byte> ToMemory()

--- a/src/neo-vm/Types/ByteArray.cs
+++ b/src/neo-vm/Types/ByteArray.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace Neo.VM.Types
 {
     [DebuggerDisplay("Type={GetType().Name}, Value={System.BitConverter.ToString(value.ToArray()).Replace(\"-\", string.Empty)}")]
-    public class ByteArray : StackItem
+    public class ByteArray : PrimitiveType
     {
         private readonly ReadOnlyMemory<byte> value;
 
@@ -13,32 +13,9 @@ namespace Neo.VM.Types
             this.value = value;
         }
 
-        public override bool Equals(StackItem other)
+        public override int GetByteLength()
         {
-            if (ReferenceEquals(this, other)) return true;
-            if (other is null) return false;
-            ReadOnlySpan<byte> bytes_other;
-            try
-            {
-                bytes_other = other.GetByteArray();
-            }
-            catch (NotSupportedException)
-            {
-                return false;
-            }
-            return Unsafe.MemoryEquals(value.Span, bytes_other);
-        }
-
-        public override bool GetBoolean()
-        {
-            if (value.Length > ExecutionEngine.MaxSizeForBigInteger)
-                return true;
-            return Unsafe.NotZero(value.Span);
-        }
-
-        public override ReadOnlySpan<byte> GetByteArray()
-        {
-            return value.Span;
+            return value.Length;
         }
 
         internal override ReadOnlyMemory<byte> ToMemory()

--- a/src/neo-vm/Types/CompoundType.cs
+++ b/src/neo-vm/Types/CompoundType.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Neo.VM.Types
 {
     public abstract class CompoundType : StackItem
@@ -9,6 +11,11 @@ namespace Neo.VM.Types
         public override bool Equals(StackItem other)
         {
             return ReferenceEquals(this, other);
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException();
         }
 
         public override bool ToBoolean()

--- a/src/neo-vm/Types/CompoundType.cs
+++ b/src/neo-vm/Types/CompoundType.cs
@@ -1,0 +1,19 @@
+namespace Neo.VM.Types
+{
+    public abstract class CompoundType : StackItem
+    {
+        public abstract int Count { get; }
+
+        public abstract void Clear();
+
+        public override bool Equals(StackItem other)
+        {
+            return ReferenceEquals(this, other);
+        }
+
+        public override bool ToBoolean()
+        {
+            return true;
+        }
+    }
+}

--- a/src/neo-vm/Types/Integer.cs
+++ b/src/neo-vm/Types/Integer.cs
@@ -5,7 +5,7 @@ using System.Numerics;
 namespace Neo.VM.Types
 {
     [DebuggerDisplay("Type={GetType().Name}, Value={value}")]
-    public class Integer : StackItem
+    public class Integer : PrimitiveType
     {
         private int _length = -1;
         private readonly BigInteger value;
@@ -20,31 +20,7 @@ namespace Neo.VM.Types
             if (ReferenceEquals(this, other)) return true;
             if (other is null) return false;
             if (other is Integer i) return value == i.value;
-            ReadOnlySpan<byte> bytes_other;
-            try
-            {
-                bytes_other = other.GetByteArray();
-            }
-            catch (NotSupportedException)
-            {
-                return false;
-            }
-            return Unsafe.MemoryEquals(GetByteArray(), bytes_other);
-        }
-
-        public override BigInteger GetBigInteger()
-        {
-            return value;
-        }
-
-        public override bool GetBoolean()
-        {
-            return !value.IsZero;
-        }
-
-        public override ReadOnlySpan<byte> GetByteArray()
-        {
-            return value.IsZero ? ReadOnlySpan<byte>.Empty : value.ToByteArray();
+            return base.Equals(other);
         }
 
         public override int GetByteLength()
@@ -52,6 +28,16 @@ namespace Neo.VM.Types
             if (_length == -1)
                 _length = value.GetByteCount();
             return _length;
+        }
+
+        public override BigInteger ToBigInteger()
+        {
+            return value;
+        }
+
+        public override bool ToBoolean()
+        {
+            return !value.IsZero;
         }
 
         internal override ReadOnlyMemory<byte> ToMemory()

--- a/src/neo-vm/Types/InteropInterface.cs
+++ b/src/neo-vm/Types/InteropInterface.cs
@@ -1,9 +1,15 @@
+using System;
 using System.Diagnostics;
 
 namespace Neo.VM.Types
 {
     public abstract class InteropInterface : StackItem
     {
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException();
+        }
+
         public abstract T GetInterface<T>() where T : class;
     }
 

--- a/src/neo-vm/Types/InteropInterface.cs
+++ b/src/neo-vm/Types/InteropInterface.cs
@@ -1,21 +1,10 @@
-using System;
 using System.Diagnostics;
 
 namespace Neo.VM.Types
 {
     public abstract class InteropInterface : StackItem
     {
-        public override ReadOnlySpan<byte> GetByteArray()
-        {
-            throw new NotSupportedException();
-        }
-
         public abstract T GetInterface<T>() where T : class;
-
-        internal override ReadOnlyMemory<byte> ToMemory()
-        {
-            throw new NotSupportedException();
-        }
     }
 
     [DebuggerDisplay("Type={GetType().Name}, Value={_object}")]
@@ -37,14 +26,14 @@ namespace Neo.VM.Types
             return _object.Equals(i._object);
         }
 
-        public override bool GetBoolean()
-        {
-            return _object != null;
-        }
-
         public override I GetInterface<I>()
         {
             return _object as I;
+        }
+
+        public override bool ToBoolean()
+        {
+            return _object != null;
         }
 
         public static implicit operator T(InteropInterface<T> @interface)

--- a/src/neo-vm/Types/Map.cs
+++ b/src/neo-vm/Types/Map.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,11 +6,11 @@ using System.Runtime.CompilerServices;
 namespace Neo.VM.Types
 {
     [DebuggerDisplay("Type={GetType().Name}, Count={Count}")]
-    public class Map : StackItem, ICollection, IDictionary<StackItem, StackItem>
+    public class Map : CompoundType, IDictionary<PrimitiveType, StackItem>
     {
-        private readonly Dictionary<StackItem, StackItem> dictionary;
+        private readonly Dictionary<PrimitiveType, StackItem> dictionary;
 
-        public StackItem this[StackItem key]
+        public StackItem this[PrimitiveType key]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => dictionary[key];
@@ -19,74 +18,50 @@ namespace Neo.VM.Types
             set => dictionary[key] = value;
         }
 
-        public ICollection<StackItem> Keys => dictionary.Keys;
+        public ICollection<PrimitiveType> Keys => dictionary.Keys;
         public ICollection<StackItem> Values => dictionary.Values;
-        public int Count => dictionary.Count;
+        public override int Count => dictionary.Count;
         public bool IsReadOnly => false;
 
-        bool ICollection.IsSynchronized => false;
-        object ICollection.SyncRoot => dictionary;
+        public Map() : this(new Dictionary<PrimitiveType, StackItem>()) { }
 
-        public Map() : this(new Dictionary<StackItem, StackItem>()) { }
-
-        public Map(Dictionary<StackItem, StackItem> value)
+        public Map(Dictionary<PrimitiveType, StackItem> value)
         {
             dictionary = value;
         }
 
-        public void Add(StackItem key, StackItem value)
+        public void Add(PrimitiveType key, StackItem value)
         {
             dictionary.Add(key, value);
         }
 
-        void ICollection<KeyValuePair<StackItem, StackItem>>.Add(KeyValuePair<StackItem, StackItem> item)
+        void ICollection<KeyValuePair<PrimitiveType, StackItem>>.Add(KeyValuePair<PrimitiveType, StackItem> item)
         {
             dictionary.Add(item.Key, item.Value);
         }
 
-        public void Clear()
+        public override void Clear()
         {
             dictionary.Clear();
         }
 
-        bool ICollection<KeyValuePair<StackItem, StackItem>>.Contains(KeyValuePair<StackItem, StackItem> item)
+        bool ICollection<KeyValuePair<PrimitiveType, StackItem>>.Contains(KeyValuePair<PrimitiveType, StackItem> item)
         {
             return dictionary.ContainsKey(item.Key);
         }
 
-        public bool ContainsKey(StackItem key)
+        public bool ContainsKey(PrimitiveType key)
         {
             return dictionary.ContainsKey(key);
         }
 
-        void ICollection<KeyValuePair<StackItem, StackItem>>.CopyTo(KeyValuePair<StackItem, StackItem>[] array, int arrayIndex)
+        void ICollection<KeyValuePair<PrimitiveType, StackItem>>.CopyTo(KeyValuePair<PrimitiveType, StackItem>[] array, int arrayIndex)
         {
-            foreach (KeyValuePair<StackItem, StackItem> item in dictionary)
+            foreach (KeyValuePair<PrimitiveType, StackItem> item in dictionary)
                 array[arrayIndex++] = item;
         }
 
-        void ICollection.CopyTo(System.Array array, int index)
-        {
-            foreach (KeyValuePair<StackItem, StackItem> item in dictionary)
-                array.SetValue(item, index++);
-        }
-
-        public override bool Equals(StackItem other)
-        {
-            return ReferenceEquals(this, other);
-        }
-
-        public override bool GetBoolean()
-        {
-            return true;
-        }
-
-        public override ReadOnlySpan<byte> GetByteArray()
-        {
-            throw new NotSupportedException();
-        }
-
-        IEnumerator<KeyValuePair<StackItem, StackItem>> IEnumerable<KeyValuePair<StackItem, StackItem>>.GetEnumerator()
+        IEnumerator<KeyValuePair<PrimitiveType, StackItem>> IEnumerable<KeyValuePair<PrimitiveType, StackItem>>.GetEnumerator()
         {
             return dictionary.GetEnumerator();
         }
@@ -96,22 +71,17 @@ namespace Neo.VM.Types
             return dictionary.GetEnumerator();
         }
 
-        public bool Remove(StackItem key)
+        public bool Remove(PrimitiveType key)
         {
             return dictionary.Remove(key);
         }
 
-        bool ICollection<KeyValuePair<StackItem, StackItem>>.Remove(KeyValuePair<StackItem, StackItem> item)
+        bool ICollection<KeyValuePair<PrimitiveType, StackItem>>.Remove(KeyValuePair<PrimitiveType, StackItem> item)
         {
             return dictionary.Remove(item.Key);
         }
 
-        internal override ReadOnlyMemory<byte> ToMemory()
-        {
-            throw new NotSupportedException();
-        }
-
-        public bool TryGetValue(StackItem key, out StackItem value)
+        public bool TryGetValue(PrimitiveType key, out StackItem value)
         {
             return dictionary.TryGetValue(key, out value);
         }

--- a/src/neo-vm/Types/Null.cs
+++ b/src/neo-vm/Types/Null.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Neo.VM.Types
 {
     public class Null : StackItem
@@ -14,19 +12,9 @@ namespace Neo.VM.Types
             return false;
         }
 
-        public override bool GetBoolean()
+        public override bool ToBoolean()
         {
             return false;
-        }
-
-        public override ReadOnlySpan<byte> GetByteArray()
-        {
-            throw new NotSupportedException();
-        }
-
-        internal override ReadOnlyMemory<byte> ToMemory()
-        {
-            throw new NotSupportedException();
         }
     }
 }

--- a/src/neo-vm/Types/Null.cs
+++ b/src/neo-vm/Types/Null.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Neo.VM.Types
 {
     public class Null : StackItem
@@ -10,6 +12,11 @@ namespace Neo.VM.Types
             if (other is null) return true;
             if (other is Null) return true;
             return false;
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException();
         }
 
         public override bool ToBoolean()

--- a/src/neo-vm/Types/PrimitiveType.cs
+++ b/src/neo-vm/Types/PrimitiveType.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Numerics;
+
+namespace Neo.VM.Types
+{
+    public abstract class PrimitiveType : StackItem
+    {
+        public override bool Equals(StackItem other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            if (other is null) return false;
+            if (!(other is PrimitiveType p)) return false;
+            return Unsafe.MemoryEquals(ToByteArray(), p.ToByteArray());
+        }
+
+        public virtual int GetByteLength()
+        {
+            return ToByteArray().Length;
+        }
+
+        public sealed override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                foreach (byte element in ToByteArray())
+                    hash = hash * 31 + element;
+                return hash;
+            }
+        }
+
+        public virtual BigInteger ToBigInteger()
+        {
+            return new BigInteger(ToByteArray());
+        }
+
+        public override bool ToBoolean()
+        {
+            ReadOnlySpan<byte> value = ToByteArray();
+            if (value.Length > ExecutionEngine.MaxSizeForBigInteger)
+                return true;
+            return Unsafe.NotZero(value);
+        }
+
+        public ReadOnlySpan<byte> ToByteArray()
+        {
+            return ToMemory().Span;
+        }
+
+        internal abstract ReadOnlyMemory<byte> ToMemory();
+    }
+}

--- a/src/neo-vm/Types/PrimitiveType.cs
+++ b/src/neo-vm/Types/PrimitiveType.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace Neo.VM.Types
 {
@@ -42,6 +43,7 @@ namespace Neo.VM.Types
             return Unsafe.NotZero(value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan<byte> ToByteArray()
         {
             return ToMemory().Span;

--- a/src/neo-vm/Types/StackItem.cs
+++ b/src/neo-vm/Types/StackItem.cs
@@ -29,10 +29,7 @@ namespace Neo.VM.Types
             return new InteropInterface<T>(value);
         }
 
-        public override int GetHashCode()
-        {
-            throw new NotSupportedException();
-        }
+        public abstract override int GetHashCode();
 
         public abstract bool ToBoolean();
 

--- a/src/neo-vm/Types/StackItem.cs
+++ b/src/neo-vm/Types/StackItem.cs
@@ -1,12 +1,9 @@
-using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
-using Array = Neo.VM.Types.Array;
-using Boolean = Neo.VM.Types.Boolean;
 
-namespace Neo.VM
+namespace Neo.VM.Types
 {
     public abstract class StackItem : IEquatable<StackItem>
     {
@@ -32,37 +29,12 @@ namespace Neo.VM
             return new InteropInterface<T>(value);
         }
 
-        public virtual BigInteger GetBigInteger()
-        {
-            return new BigInteger(GetByteArray());
-        }
-
-        public abstract bool GetBoolean();
-
-        public abstract ReadOnlySpan<byte> GetByteArray();
-
-        public virtual int GetByteLength()
-        {
-            return GetByteArray().Length;
-        }
-
         public override int GetHashCode()
         {
-            unchecked
-            {
-                int hash = 17;
-                foreach (byte element in GetByteArray())
-                    hash = hash * 31 + element;
-                return hash;
-            }
+            throw new NotSupportedException();
         }
 
-        public virtual string GetString()
-        {
-            return Encoding.UTF8.GetString(GetByteArray());
-        }
-
-        internal abstract ReadOnlyMemory<byte> ToMemory();
+        public abstract bool ToBoolean();
 
         public static implicit operator StackItem(int value)
         {

--- a/src/neo-vm/Types/StackItem.cs
+++ b/src/neo-vm/Types/StackItem.cs
@@ -15,8 +15,7 @@ namespace Neo.VM.Types
 
         public sealed override bool Equals(object obj)
         {
-            if (obj == null) return false;
-            if (obj == this) return true;
+            if (ReferenceEquals(obj, this)) return true;
             if (obj is StackItem other)
                 return Equals(other);
             return false;

--- a/tests/neo-vm.Tests/Types/TestEngine.cs
+++ b/tests/neo-vm.Tests/Types/TestEngine.cs
@@ -1,4 +1,5 @@
 using Neo.VM;
+using Neo.VM.Types;
 
 namespace Neo.Test.Types
 {

--- a/tests/neo-vm.Tests/UtDebugger.cs
+++ b/tests/neo-vm.Tests/UtDebugger.cs
@@ -96,7 +96,7 @@ namespace Neo.Test
 
                 debugger.Execute();
 
-                Assert.AreEqual(true, engine.ResultStack.Pop().GetBoolean());
+                Assert.AreEqual(true, engine.ResultStack.Pop().ToBoolean());
                 Assert.AreEqual(VMState.HALT, engine.State);
 
                 // Test step over again
@@ -152,7 +152,7 @@ namespace Neo.Test
                 Assert.AreEqual(VMState.BREAK, debugger.StepInto());
                 Assert.AreEqual(VMState.HALT, debugger.StepInto());
 
-                Assert.AreEqual(true, engine.ResultStack.Pop().GetBoolean());
+                Assert.AreEqual(true, engine.ResultStack.Pop().ToBoolean());
                 Assert.AreEqual(VMState.HALT, engine.State);
 
                 // Test step into again
@@ -196,7 +196,7 @@ namespace Neo.Test
 
                 debugger.Execute();
 
-                Assert.AreEqual(true, engine.ResultStack.Pop().GetBoolean());
+                Assert.AreEqual(true, engine.ResultStack.Pop().ToBoolean());
                 Assert.AreEqual(VMState.HALT, engine.State);
             }
         }

--- a/tests/neo-vm.Tests/UtStackItem.cs
+++ b/tests/neo-vm.Tests/UtStackItem.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Neo.VM;
 using Neo.VM.Types;
 using System.Collections.Generic;
 using System.Numerics;
@@ -55,73 +54,65 @@ namespace Neo.Test
             StackItem item = int.MaxValue;
 
             Assert.IsInstanceOfType(item, typeof(Integer));
-            Assert.AreEqual(new BigInteger(int.MaxValue), item.GetBigInteger());
+            Assert.AreEqual(new BigInteger(int.MaxValue), ((Integer)item).ToBigInteger());
 
             // Unsigned integer
 
             item = uint.MaxValue;
 
             Assert.IsInstanceOfType(item, typeof(Integer));
-            Assert.AreEqual(new BigInteger(uint.MaxValue), item.GetBigInteger());
+            Assert.AreEqual(new BigInteger(uint.MaxValue), ((Integer)item).ToBigInteger());
 
             // Signed long
 
             item = long.MaxValue;
 
             Assert.IsInstanceOfType(item, typeof(Integer));
-            Assert.AreEqual(new BigInteger(long.MaxValue), item.GetBigInteger());
+            Assert.AreEqual(new BigInteger(long.MaxValue), ((Integer)item).ToBigInteger());
 
             // Unsigned long
 
             item = ulong.MaxValue;
 
             Assert.IsInstanceOfType(item, typeof(Integer));
-            Assert.AreEqual(new BigInteger(ulong.MaxValue), item.GetBigInteger());
+            Assert.AreEqual(new BigInteger(ulong.MaxValue), ((Integer)item).ToBigInteger());
 
             // BigInteger
 
             item = BigInteger.MinusOne;
 
             Assert.IsInstanceOfType(item, typeof(Integer));
-            Assert.AreEqual(new BigInteger(-1), item.GetBigInteger());
+            Assert.AreEqual(new BigInteger(-1), ((Integer)item).ToBigInteger());
 
             // Boolean
 
             item = true;
 
             Assert.IsInstanceOfType(item, typeof(Boolean));
-            Assert.IsTrue(item.GetBoolean());
+            Assert.IsTrue(item.ToBoolean());
 
             // ByteArray
 
             item = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
 
             Assert.IsInstanceOfType(item, typeof(ByteArray));
-            CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 }, item.GetByteArray().ToArray());
-
-            // String
-
-            item = "NEO - 种智能经济分布式网络";
-
-            Assert.IsInstanceOfType(item, typeof(ByteArray));
-            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("NEO - 种智能经济分布式网络"), item.GetByteArray().ToArray());
-            Assert.AreEqual("NEO - 种智能经济分布式网络", item.GetString());
+            CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 }, ((ByteArray)item).ToByteArray().ToArray());
 
             // Array
 
             item = new StackItem[] { true, false };
 
             Assert.IsInstanceOfType(item, typeof(Array));
-            Assert.IsTrue(((Array)item)[0].GetBoolean());
-            Assert.IsFalse(((Array)item)[1].GetBoolean());
+            Assert.IsTrue(((Array)item)[0].ToBoolean());
+            Assert.IsFalse(((Array)item)[1].ToBoolean());
 
             // List
 
             item = new List<StackItem>(new StackItem[] { true, false });
 
             Assert.IsInstanceOfType(item, typeof(Array));
-            Assert.IsTrue(((Array)item)[0].GetBoolean());
-            Assert.IsFalse(((Array)item)[1].GetBoolean());
+            Assert.IsTrue(((Array)item)[0].ToBoolean());
+            Assert.IsFalse(((Array)item)[1].ToBoolean());
 
             // Interop
 

--- a/tests/neo-vm.Tests/VMJsonTestBase.cs
+++ b/tests/neo-vm.Tests/VMJsonTestBase.cs
@@ -1,6 +1,7 @@
 using Neo.Test.Extensions;
 using Neo.Test.Types;
 using Neo.VM;
+using Neo.VM.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -202,9 +203,9 @@ namespace Neo.Test
                             ["type"] = type,
                         };
                     }
-                case VM.Types.Boolean v: value = new JValue(v.GetBoolean()); break;
-                case VM.Types.Integer v: value = new JValue(v.GetBigInteger().ToString()); break;
-                case VM.Types.ByteArray v: value = new JValue(v.GetByteArray().ToArray()); break;
+                case VM.Types.Boolean v: value = new JValue(v.ToBoolean()); break;
+                case VM.Types.Integer v: value = new JValue(v.ToBigInteger().ToString()); break;
+                case VM.Types.ByteArray v: value = new JValue(v.ToByteArray().ToArray()); break;
                 //case VM.Types.Struct v:
                 case VM.Types.Array v:
                     {
@@ -224,7 +225,7 @@ namespace Neo.Test
 
                         foreach (var entry in v)
                         {
-                            jdic.Add(entry.Key.GetByteArray().ToArray().ToHexString(), ItemToJson(entry.Value));
+                            jdic.Add(entry.Key.ToByteArray().ToArray().ToHexString(), ItemToJson(entry.Value));
                         }
 
                         value = jdic;


### PR DESCRIPTION
When there are no items in the stack, we throw an exception, with this change, we can avoid it and `return false` clean.