### PR TITLE
Disable `PublishGithub`

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -33,7 +33,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
   PublishGithub:
-    if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
+    if: false && github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
     needs: Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -33,6 +33,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
   PublishGithub:
+    # Because sometimes this action is not working as expected we will disable it until determine that it's more stable
     if: false && github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
     needs: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because it always fails. We can wait for Github's service to become more stable before enabling it.