### PR TITLE
fix bug

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -442,7 +442,7 @@ namespace Neo.VM
                         if (instruction.TokenU8_1 > 0)
                         {
                             StackItem[] items = new StackItem[instruction.TokenU8_1];
-                            for (int i = 0; i< instruction.TokenU8_1; i++)
+                            for (int i = 0; i < instruction.TokenU8_1; i++)
                                 if (!TryPop(out items[i]))
                                     return false;
                             context.Arguments = new Slot(items, ReferenceCounter);

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -442,7 +442,7 @@ namespace Neo.VM
                         if (instruction.TokenU8_1 > 0)
                         {
                             StackItem[] items = new StackItem[instruction.TokenU8_1];
-                            for (int i = instruction.TokenU8_1 - 1; i >= 0; i--)
+                            for (int i = 0; i< instruction.TokenU8_1; i++)
                                 if (!TryPop(out items[i]))
                                     return false;
                             context.Arguments = new Slot(items, ReferenceCounter);
@@ -735,7 +735,8 @@ namespace Neo.VM
                 case OpCode.SHL:
                     {
                         if (!TryPop(out int shift)) return false;
-                        if (!CheckShift(shift)) return false;
+                        //shift allow >32 and <0 ,got a  %32 value
+                        //if (!CheckShift(shift)) return false;
                         if (shift == 0) break;
                         if (!TryPop(out BigInteger x)) return false;
                         Push(x << shift);
@@ -744,7 +745,8 @@ namespace Neo.VM
                 case OpCode.SHR:
                     {
                         if (!TryPop(out int shift)) return false;
-                        if (!CheckShift(shift)) return false;
+                        //if (!CheckShift(shift)) return false;
+                        //shift allow >32 and <0 ,got a  %32 value
                         if (shift == 0) break;
                         if (!TryPop(out BigInteger x)) return false;
                         Push(x >> shift);

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -735,8 +735,7 @@ namespace Neo.VM
                 case OpCode.SHL:
                     {
                         if (!TryPop(out int shift)) return false;
-                        //shift allow >32 and <0 ,got a  %32 value
-                        //if (!CheckShift(shift)) return false;
+                        if (!CheckShift(shift)) return false;
                         if (shift == 0) break;
                         if (!TryPop(out BigInteger x)) return false;
                         Push(x << shift);
@@ -745,8 +744,7 @@ namespace Neo.VM
                 case OpCode.SHR:
                     {
                         if (!TryPop(out int shift)) return false;
-                        //if (!CheckShift(shift)) return false;
-                        //shift allow >32 and <0 ,got a  %32 value
+                        if (!CheckShift(shift)) return false;
                         if (shift == 0) break;
                         if (!TryPop(out BigInteger x)) return false;
                         Push(x >> shift);

--- a/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG1.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG1.json
@@ -56,7 +56,7 @@
             "resultStack": [
               {
                 "type": "Integer",
-                "value": 2
+                "value": 1
               }
             ]
           }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG2.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG2.json
@@ -57,7 +57,7 @@
             "resultStack": [
               {
                 "type": "Integer",
-                "value": 3
+                "value": 1
               }
             ]
           }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG3.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG3.json
@@ -58,7 +58,7 @@
             "resultStack": [
               {
                 "type": "Integer",
-                "value": 4
+                "value": 1
               }
             ]
           }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG4.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG4.json
@@ -59,7 +59,7 @@
             "resultStack": [
               {
                 "type": "Integer",
-                "value": 5
+                "value": 1
               }
             ]
           }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG5.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG5.json
@@ -60,7 +60,7 @@
             "resultStack": [
               {
                 "type": "Integer",
-                "value": 6
+                "value": 1
               }
             ]
           }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG6.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Slot/LDARG6.json
@@ -61,7 +61,7 @@
             "resultStack": [
               {
                 "type": "Integer",
-                "value": 7
+                "value": 1
               }
             ]
           }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Splice/CAT.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Splice/CAT.json
@@ -292,8 +292,8 @@
         "0x30",
         "INITSLOT",
         "0002",
-        "LDARG0",
         "LDARG1",
+        "LDARG0",
         "CAT"
       ],
       "steps": [
@@ -333,15 +333,15 @@
             "invocationStack": [
               {
                 "instructionPointer": 13,
-                "nextInstruction": "LDARG0",
+                "nextInstruction": "LDARG1",
                 "arguments": [
                   {
                     "type": "Buffer",
-                    "value": "AA"
+                    "value": "BB"
                   },
                   {
                     "type": "Buffer",
-                    "value": "BB"
+                    "value": "AA"
                   }
                 ]
               }
@@ -372,11 +372,11 @@
                 "arguments": [
                   {
                     "type": "Buffer",
-                    "value": "AA"
+                    "value": "BB"
                   },
                   {
                     "type": "Buffer",
-                    "value": "BB"
+                    "value": "AA"
                   }
                 ]
               }
@@ -402,11 +402,11 @@
                 "arguments": [
                   {
                     "type": "Buffer",
-                    "value": "AA"
+                    "value": "BB"
                   },
                   {
                     "type": "Buffer",
-                    "value": "BB"
+                    "value": "AA"
                   }
                 ]
               }


### PR DESCRIPTION
fixed #282 

1.INITSLOT got error order

trypop(out item[1]); // =>pop1 get param1:"nep5_transfer",and set it to slot1
trypop(out item[0]); // =>pop2 get param2: [from,to,value] ,and set it to slot0
fix it

