### PR TITLE
Allow to use the OperandSizeAttribute outside neo-vm 

### DIFF
--- a/src/neo-vm/OperandSizeAttribute.cs
+++ b/src/neo-vm/OperandSizeAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Neo.VM
 {
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-    internal class OperandSizeAttribute : Attribute
+    public class OperandSizeAttribute : Attribute
     {
         public int Size { get; set; }
         public int SizePrefix { get; set; }


### PR DESCRIPTION
This can prevent the duplicate in compiler https://github.com/neo-project/neo-devpack-dotnet/pull/182/files#diff-444cbe5596606ed74000b915750fe568R6

Also it could be useful for parsers.