### PR TITLE
Enlarge MaxStackSize

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -22,7 +22,7 @@ namespace Neo.VM
         /// <summary>
         /// Set the max Stack Size
         /// </summary>
-        public virtual uint MaxStackSize => 2 * 1024;
+        public virtual uint MaxStackSize => 20 * 1024;
 
         /// <summary>
         /// Set Max Item Size


### PR DESCRIPTION
Close [#1410](https://github.com/neo-project/neo/issues/1410).
When tx count is 512 in one block, the stack size reaches to 2053. Here enlarge `MaxStackSize` by 10 times for the capability to execute more transaction fee operation when persisting block.