### PR TITLE
Add nullable checks

### DIFF
--- a/src/neo-vm/Collections/OrderedDictionary.cs
+++ b/src/neo-vm/Collections/OrderedDictionary.cs
@@ -6,11 +6,18 @@ using System.Linq;
 namespace Neo.VM.Collections
 {
     internal class OrderedDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+        where TValue : class
     {
         private class TItem
         {
             public TKey Key;
             public TValue Value;
+
+            public TItem(TKey key, TValue value)
+            {
+                Key = key;
+                Value = value;
+            }
         }
 
         private class InternalCollection : KeyedCollection<TKey, TItem>
@@ -45,11 +52,7 @@ namespace Neo.VM.Collections
 
         public void Add(TKey key, TValue value)
         {
-            collection.Add(new TItem
-            {
-                Key = key,
-                Value = value
-            });
+            collection.Add(new TItem(key, value));
         }
 
         public bool ContainsKey(TKey key)
@@ -62,6 +65,7 @@ namespace Neo.VM.Collections
             return collection.Remove(key);
         }
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         public bool TryGetValue(TKey key, out TValue value)
         {
             if (collection.Contains(key))
@@ -72,6 +76,7 @@ namespace Neo.VM.Collections
             value = default;
             return false;
         }
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
         {

--- a/src/neo-vm/Debugger.cs
+++ b/src/neo-vm/Debugger.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Neo.VM
@@ -36,6 +37,8 @@ namespace Neo.VM
             engine.ExecuteNext();
             if (engine.State == VMState.NONE && engine.InvocationStack.Count > 0 && break_points.Count > 0)
             {
+                if (engine.CurrentContext == null) throw new ArgumentException(nameof(engine.CurrentContext));
+
                 if (break_points.TryGetValue(engine.CurrentContext.Script, out HashSet<uint> hashset) && hashset.Contains((uint)engine.CurrentContext.InstructionPointer))
                     engine.State = VMState.BREAK;
             }

--- a/src/neo-vm/EvaluationStack.cs
+++ b/src/neo-vm/EvaluationStack.cs
@@ -95,6 +95,8 @@ namespace Neo.VM
             return TryRemove(0, out item);
         }
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS8601 // Possible null reference assignment.
         internal bool TryRemove<T>(int index, out T item) where T : StackItem
         {
             if (index >= innerList.Count)
@@ -118,5 +120,7 @@ namespace Neo.VM
             referenceCounter.RemoveStackReference(item);
             return true;
         }
+#pragma warning restore CS8601 // Possible null reference assignment.
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 }

--- a/src/neo-vm/ExecutionContext.cs
+++ b/src/neo-vm/ExecutionContext.cs
@@ -25,11 +25,11 @@ namespace Neo.VM
         /// </summary>
         public EvaluationStack EvaluationStack { get; }
 
-        public Slot StaticFields { get; internal set; }
+        public Slot? StaticFields { get; internal set; }
 
-        public Slot LocalVariables { get; internal set; }
+        public Slot? LocalVariables { get; internal set; }
 
-        public Slot Arguments { get; internal set; }
+        public Slot? Arguments { get; internal set; }
 
         /// <summary>
         /// Instruction pointer

--- a/src/neo-vm/ReferenceCounter.cs
+++ b/src/neo-vm/ReferenceCounter.cs
@@ -1,5 +1,6 @@
 using Neo.VM.Collections;
 using Neo.VM.Types;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,7 +11,7 @@ namespace Neo.VM
         private class Entry
         {
             public int StackReferences;
-            public Dictionary<CompoundType, int> ObjectReferences;
+            public Dictionary<CompoundType, int>? ObjectReferences;
         }
 
         private readonly Dictionary<CompoundType, Entry> counter = new Dictionary<CompoundType, Entry>(ReferenceEqualityComparer.Default);
@@ -90,7 +91,10 @@ namespace Neo.VM
                     foreach (CompoundType subitem in compound.SubItems.OfType<CompoundType>())
                     {
                         if (toBeDestroyed.Contains(subitem)) continue;
+
                         Entry entry = counter[subitem];
+                        if (entry.ObjectReferences == null) throw new ArgumentException(nameof(entry.ObjectReferences));
+
                         entry.ObjectReferences.Remove(compound);
                         if (entry.StackReferences == 0)
                             zero_referred.Add(subitem);
@@ -104,7 +108,10 @@ namespace Neo.VM
         {
             references_count--;
             if (!(referred is CompoundType compound)) return;
+
             Entry entry = counter[compound];
+            if (entry.ObjectReferences == null) throw new ArgumentException(nameof(entry.ObjectReferences));
+
             entry.ObjectReferences[parent] -= 1;
             if (entry.StackReferences == 0)
                 zero_referred.Add(compound);

--- a/src/neo-vm/ScriptBuilder.cs
+++ b/src/neo-vm/ScriptBuilder.cs
@@ -23,7 +23,7 @@ namespace Neo.VM
             ms.Dispose();
         }
 
-        public ScriptBuilder Emit(OpCode op, byte[] arg = null)
+        public ScriptBuilder Emit(OpCode op, byte[]? arg = null)
         {
             writer.Write((byte)op);
             if (arg != null)
@@ -99,7 +99,7 @@ namespace Neo.VM
             return EmitPush(Encoding.UTF8.GetBytes(data));
         }
 
-        public ScriptBuilder EmitRaw(byte[] arg = null)
+        public ScriptBuilder EmitRaw(byte[]? arg = null)
         {
             if (arg != null)
                 writer.Write(arg);

--- a/src/neo-vm/Types/Array.cs
+++ b/src/neo-vm/Types/Array.cs
@@ -26,12 +26,12 @@ namespace Neo.VM.Types
         internal override int SubItemsCount => _array.Count;
         public override StackItemType Type => StackItemType.Array;
 
-        public Array(IEnumerable<StackItem> value = null)
+        public Array(IEnumerable<StackItem>? value = null)
             : this(null, value)
         {
         }
 
-        public Array(ReferenceCounter referenceCounter, IEnumerable<StackItem> value = null)
+        public Array(ReferenceCounter? referenceCounter, IEnumerable<StackItem>? value = null)
             : base(referenceCounter)
         {
             _array = value switch

--- a/src/neo-vm/Types/CompoundType.cs
+++ b/src/neo-vm/Types/CompoundType.cs
@@ -7,9 +7,9 @@ namespace Neo.VM.Types
     [DebuggerDisplay("Type={GetType().Name}, Count={Count}")]
     public abstract class CompoundType : StackItem
     {
-        protected readonly ReferenceCounter ReferenceCounter;
+        protected readonly ReferenceCounter? ReferenceCounter;
 
-        protected CompoundType(ReferenceCounter referenceCounter)
+        protected CompoundType(ReferenceCounter? referenceCounter)
         {
             this.ReferenceCounter = referenceCounter;
         }

--- a/src/neo-vm/Types/Map.cs
+++ b/src/neo-vm/Types/Map.cs
@@ -41,7 +41,7 @@ namespace Neo.VM.Types
         public override StackItemType Type => StackItemType.Map;
         public IEnumerable<StackItem> Values => dictionary.Values;
 
-        public Map(ReferenceCounter referenceCounter = null)
+        public Map(ReferenceCounter? referenceCounter = null)
             : base(referenceCounter)
         {
         }

--- a/src/neo-vm/Types/Struct.cs
+++ b/src/neo-vm/Types/Struct.cs
@@ -7,12 +7,12 @@ namespace Neo.VM.Types
     {
         public override StackItemType Type => StackItemType.Struct;
 
-        public Struct(IEnumerable<StackItem> value = null)
+        public Struct(IEnumerable<StackItem>? value = null)
             : this(null, value)
         {
         }
 
-        public Struct(ReferenceCounter referenceCounter, IEnumerable<StackItem> value = null)
+        public Struct(ReferenceCounter? referenceCounter, IEnumerable<StackItem>? value = null)
             : base(referenceCounter, value)
         {
         }

--- a/src/neo-vm/neo-vm.csproj
+++ b/src/neo-vm/neo-vm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>2016-2019 The Neo Project</Copyright>
@@ -17,6 +17,7 @@
     <RepositoryUrl>https://github.com/neo-project/neo-vm.git</RepositoryUrl>
     <RootNamespace>Neo.VM</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
As described here https://docs.microsoft.com/es-es/dotnet/csharp/tutorials/nullable-reference-types

C# 8.0 bring us the possiblitiy of avoid a lot of NullExceptions, we have the case of https://github.com/neo-project/neo-devpack-dotnet/pull/187#issuecomment-581733264, I think that we should add in a progressive way this flag in all the neo projects, in order to reduce this kind of errors.