### PR TITLE
Optimize GetHashCode

### DIFF
--- a/src/neo-vm/Types/Buffer.cs
+++ b/src/neo-vm/Types/Buffer.cs
@@ -47,13 +47,7 @@ namespace Neo.VM.Types
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                int hash = 17;
-                foreach (byte element in InnerBuffer)
-                    hash = hash * 31 + element;
-                return hash;
-            }
+            return Size;
         }
 
         public override bool ToBoolean()


### PR DESCRIPTION
Related to @ixje issue https://github.com/neo-project/neo-vm/issues/281

`GetHashCode` should provide a easy way for check if two objects are equal, but if `GetHashCode` returns the same value, then it will call `Equals` method, due the `Equals` implementation is a reference check, has no sense that `GetHashCode` compute a real HashCode.


> Two objects that are equal return hash codes that are equal. However, the reverse is not true: equal hash codes do not imply object equality, because different (unequal) objects can have identical hash codes. Furthermore, .NET does not guarantee the default implementation of the GetHashCode method, and the value this method returns may differ between .NET implementations, such as different versions of .NET Framework and .NET Core, and platforms, such as 32-bit and 64-bit platforms. For these reasons, do not use the default implementation of this method as a unique object identifier for hashing purposes. Two consequences follow from this:
> - You should not assume that equal hash codes imply object equality.
> - You should never persist or use a hash code outside the application domain in which it was created, because the same object may hash across application domains, processes, and platforms.


*Source: https://docs.microsoft.com/en-us/dotnet/api/system.object.gethashcode?view=netframework-4.8*