### PR TITLE
Fixed a bug where StaticFields could not be initialized correctly in non-entry point

### DIFF
--- a/src/neo-vm/ExecutionContext.SharedStates.cs
+++ b/src/neo-vm/ExecutionContext.SharedStates.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace Neo.VM
+{
+    partial class ExecutionContext
+    {
+        private class SharedStates
+        {
+            public readonly Script Script;
+            public readonly EvaluationStack EvaluationStack;
+            public Slot StaticFields;
+            public readonly Dictionary<Type, object> States;
+
+            public SharedStates(Script script, ReferenceCounter referenceCounter)
+            {
+                this.Script = script;
+                this.EvaluationStack = new EvaluationStack(referenceCounter);
+                this.States = new Dictionary<Type, object>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
If `INITSSLOT` is not called in an entry point, the `StaticFields` won't be initialized correctly. This PR fixed it.