### PR TITLE
Remove two arrays search

### DIFF
--- a/src/neo-vm/Instruction.cs
+++ b/src/neo-vm/Instruction.cs
@@ -150,7 +150,15 @@ namespace Neo.VM
         {
             OpCode = (OpCode)script[ip++];
             var entry = OperandSizeTable[(byte)OpCode];
-            int operandSize = entry.GetOperandSize(script, ip);
+            int operandSize = entry.SizePrefix switch
+            {
+                0 => entry.Size,
+                1 => script[ip],
+                2 => BitConverter.ToUInt16(script, ip),
+                4 => BitConverter.ToInt32(script, ip),
+                _ => throw new FormatException(),
+            };
+
             if (operandSize > 0)
             {
                 ip += entry.SizePrefix;

--- a/src/neo-vm/OperandSizeAttribute.cs
+++ b/src/neo-vm/OperandSizeAttribute.cs
@@ -7,17 +7,5 @@ namespace Neo.VM
     {
         public int Size { get; set; }
         public int SizePrefix { get; set; }
-
-        public int GetOperandSize(byte[] script, int ip)
-        {
-            return SizePrefix switch
-            {
-                0 => Size,
-                1 => script[ip],
-                2 => BitConverter.ToUInt16(script, ip),
-                4 => BitConverter.ToInt32(script, ip),
-                _ => throw new FormatException(),
-            };
-        }
     }
 }

--- a/src/neo-vm/OperandSizeAttribute.cs
+++ b/src/neo-vm/OperandSizeAttribute.cs
@@ -7,5 +7,17 @@ namespace Neo.VM
     {
         public int Size { get; set; }
         public int SizePrefix { get; set; }
+
+        public int GetOperandSize(byte[] script, int ip)
+        {
+            return SizePrefix switch
+            {
+                0 => Size,
+                1 => script[ip],
+                2 => BitConverter.ToUInt16(script, ip),
+                4 => BitConverter.ToInt32(script, ip),
+                _ => throw new FormatException(),
+            };
+        }
     }
 }


### PR DESCRIPTION
We can reuse `OperandSizeAttribute` and avoid search twice in `OperandSizePrefixTable` and `OperandSizeTable`