### PR TITLE
Add Trace method to ExecutionEngine (Neo 2)

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -189,8 +189,13 @@ namespace Neo.VM
             InvocationStack.Clear();
         }
 
+        protected virtual void Trace()
+        {
+        }
+
         public void Execute()
         {
+            Trace();
             State &= ~VMState.BREAK;
             while (!State.HasFlag(VMState.HALT) && !State.HasFlag(VMState.FAULT) && !State.HasFlag(VMState.BREAK))
                 ExecuteNext();
@@ -213,6 +218,10 @@ namespace Neo.VM
                 catch
                 {
                     State = VMState.FAULT;
+                }
+                finally
+                {
+                    Trace();
                 }
             }
         }


### PR DESCRIPTION
This PR adds a virual Trace method to ExecutionEngine that subclasses can use for trace debugging. This is part of the Time Travel Debugging work announced at Consensus 2020 and was the [first neo-debugger bug filed](https://github.com/neo-project/neo-debugger/issues/1) by @lightszero. A similar PR for master branch / Neo 3 was also opened (#320 