### PR TITLE
Add Trace method to ExecutionEngine (Neo 3)

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -93,8 +93,13 @@ namespace Neo.VM
             InvocationStack.Clear();
         }
 
+        protected virtual void Trace()
+        {
+        }
+
         public VMState Execute()
         {
+            Trace();
             if (State == VMState.BREAK)
                 State = VMState.NONE;
             while (State != VMState.HALT && State != VMState.FAULT)
@@ -1241,6 +1246,10 @@ namespace Neo.VM
                 catch
                 {
                     State = VMState.FAULT;
+                }
+                finally
+                {
+                    Trace();
                 }
             }
         }


### PR DESCRIPTION
This PR adds a virual Trace method to ExecutionEngine that subclasses can use for trace debugging. This is part of the Time Travel Debugging work announced at Consensus 2020 and was the [first neo-debugger bug filed](https://github.com/neo-project/neo-debugger/issues/1) by @lightszero. A similar PR for master-2.x branch / Neo 2 was also opened (#319) 