### PR TITLE
Remove extra step from TRYCATCH test

### DIFF
--- a/tests/neo-vm.Tests/Tests/OpCodes/Control/TRY_CATCH_FINALLY6.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Control/TRY_CATCH_FINALLY6.json
@@ -21,7 +21,6 @@
         {
           "actions": [
             "stepInto",
-            "stepInto",
             "stepInto"
           ],
           "result": {


### PR DESCRIPTION
FAULT state is reached after 2 steps (`TRY` + `ABORT`), there is no need to go further.
I believe if we specify 3 steps in test, we should expect every but last step to finish with success.