### PR TITLE
Remove unused properties

### DIFF
--- a/src/neo-vm/Instruction.cs
+++ b/src/neo-vm/Instruction.cs
@@ -3,7 +3,6 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Neo.VM
 {
@@ -72,15 +71,6 @@ namespace Neo.VM
             get
             {
                 return (sbyte)Operand.Span[1];
-            }
-        }
-
-        public string TokenString
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return Encoding.ASCII.GetString(Operand.Span);
             }
         }
 

--- a/src/neo-vm/Instruction.cs
+++ b/src/neo-vm/Instruction.cs
@@ -29,15 +29,6 @@ namespace Neo.VM
             }
         }
 
-        public short TokenI16
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return BinaryPrimitives.ReadInt16LittleEndian(Operand.Span);
-            }
-        }
-
         public int TokenI32
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/neo-vm.Tests/UtScript.cs
+++ b/tests/neo-vm.Tests/UtScript.cs
@@ -70,7 +70,6 @@ namespace Neo.Test
             Assert.AreEqual(OpCode.PUSH0, ins.OpCode);
             Assert.IsTrue(ins.Operand.IsEmpty);
             Assert.AreEqual(1, ins.Size);
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => { var x = ins.TokenI16; });
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => { var x = ins.TokenU32; });
 
             ins = script.GetInstruction(1);
@@ -85,7 +84,6 @@ namespace Neo.Test
             Assert.AreEqual(OpCode.SYSCALL, ins.OpCode);
             CollectionAssert.AreEqual(new byte[] { 123, 0x00, 0x00, 0x00 }, ins.Operand.ToArray());
             Assert.AreEqual(5, ins.Size);
-            Assert.AreEqual(123, ins.TokenI16);
             Assert.AreEqual(123U, ins.TokenU32);
 
             ins = script.GetInstruction(100);

--- a/tests/neo-vm.Tests/UtScript.cs
+++ b/tests/neo-vm.Tests/UtScript.cs
@@ -79,7 +79,6 @@ namespace Neo.Test
             CollectionAssert.AreEqual(new byte[] { 0x00, 0x01, 0x00, 0x00 }, ins.Operand.ToArray());
             Assert.AreEqual(5, ins.Size);
             Assert.AreEqual(256, ins.TokenI32);
-            Assert.AreEqual(Encoding.ASCII.GetString(new byte[] { 0x00, 0x01, 0x00, 0x00 }), ins.TokenString);
 
             ins = script.GetInstruction(6);
 
@@ -87,7 +86,6 @@ namespace Neo.Test
             CollectionAssert.AreEqual(new byte[] { 123, 0x00, 0x00, 0x00 }, ins.Operand.ToArray());
             Assert.AreEqual(5, ins.Size);
             Assert.AreEqual(123, ins.TokenI16);
-            Assert.AreEqual(Encoding.ASCII.GetString(new byte[] { 123, 0x00, 0x00, 0x00 }), ins.TokenString);
             Assert.AreEqual(123U, ins.TokenU32);
 
             ins = script.GetInstruction(100);


### PR DESCRIPTION
We never use `TokenString` and `TokenI16`, we can remove them.