### PR TITLE
Optimize buffer GetHashCode and Script.Equals

### DIFF
--- a/src/neo-vm/Script.cs
+++ b/src/neo-vm/Script.cs
@@ -51,19 +51,15 @@ namespace Neo.VM
         {
             if (this == obj) return true;
             if (!(obj is Script script)) return false;
+            if (GetHashCode() != script.GetHashCode()) return false;
             return _value.AsSpan().SequenceEqual(script._value);
         }
 
-        public unsafe override int GetHashCode()
+        public override int GetHashCode()
         {
             if (_hashCode == -1)
             {
-                unchecked
-                {
-                    _hashCode = 17;
-                    foreach (byte element in _value)
-                        _hashCode = _hashCode * 31 + element;
-                }
+                _hashCode = Unsafe.GetHashCode(_value);
             }
             return _hashCode;
         }

--- a/src/neo-vm/Types/ByteString.cs
+++ b/src/neo-vm/Types/ByteString.cs
@@ -33,13 +33,7 @@ namespace Neo.VM.Types
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                int hash = 17;
-                foreach (byte element in GetSpan())
-                    hash = hash * 31 + element;
-                return hash;
-            }
+            return Unsafe.GetHashCode(GetSpan());
         }
 
         public override BigInteger GetInteger()

--- a/src/neo-vm/Unsafe.cs
+++ b/src/neo-vm/Unsafe.cs
@@ -53,10 +53,10 @@ namespace Neo.VM
                             xbp++;
                         }
                     }
+
+                    if (hashCode == -1) hashCode = 0;
                 }
             }
-
-            if (hashCode == -1) hashCode = 0;
 
             return hashCode;
         }

--- a/src/neo-vm/Unsafe.cs
+++ b/src/neo-vm/Unsafe.cs
@@ -27,5 +27,38 @@ namespace Neo.VM
             }
             return false;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetHashCode(ReadOnlySpan<byte> value)
+        {
+            int hashCode = 17;
+
+            unchecked
+            {
+                int len = value.Length;
+                if (len > 0)
+                {
+                    fixed (byte* xp = value)
+                    {
+                        int* xlp = (int*)xp;
+                        for (; len >= 4; len -= 4)
+                        {
+                            hashCode = hashCode * 31 + *xlp;
+                            xlp++;
+                        }
+                        byte* xbp = (byte*)xlp;
+                        for (; len > 0; len--)
+                        {
+                            hashCode = hashCode * 31 + *xbp;
+                            xbp++;
+                        }
+                    }
+                }
+            }
+
+            if (hashCode == -1) hashCode = 0;
+
+            return hashCode;
+        }
     }
 }


### PR DESCRIPTION
We can improve the pointer comparison improving the script comparison.