### PR TITLE
Modify Call and RET behaviors

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -140,7 +140,6 @@ namespace Neo.VM
         {
             if (position < 0 || position > CurrentContext.Script.Length)
                 throw new ArgumentOutOfRangeException(nameof(position));
-            CurrentContext.MoveNext();
             ExecutionContext context = CurrentContext.Clone();
             context.InstructionPointer = position;
             LoadContext(context);
@@ -422,7 +421,6 @@ namespace Neo.VM
                         if (InvocationStack.Count == 0)
                             State = VMState.HALT;
                         ContextUnloaded(context_pop);
-                        ipFlag = true;
                         break;
                     }
                 case OpCode.SYSCALL:

--- a/tests/neo-vm.Tests/Tests/OpCodes/Control/CALL.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Control/CALL.json
@@ -58,8 +58,8 @@
                 "nextInstruction": "PUSH0"
               },
               {
-                "instructionPointer": 2,
-                "nextInstruction": "RET"
+                "instructionPointer": 0,
+                "nextInstruction": "CALL"
               }
             ]
           }
@@ -82,8 +82,8 @@
                 ]
               },
               {
-                "instructionPointer": 2,
-                "nextInstruction": "RET",
+                "instructionPointer": 0,
+                "nextInstruction": "CALL",
                 "evaluationStack": [
                   {
                     "type": "integer",

--- a/tests/neo-vm.Tests/Tests/OpCodes/Control/CALLA.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Control/CALLA.json
@@ -82,8 +82,8 @@
                 "nextInstruction": "PUSH0"
               },
               {
-                "instructionPointer": 6,
-                "nextInstruction": "RET"
+                "instructionPointer": 5,
+                "nextInstruction": "CALLA"
               }
             ]
           }
@@ -106,8 +106,8 @@
                 ]
               },
               {
-                "instructionPointer": 6,
-                "nextInstruction": "RET",
+                "instructionPointer": 5,
+                "nextInstruction": "CALLA",
                 "evaluationStack": [
                   {
                     "type": "integer",

--- a/tests/neo-vm.Tests/Tests/OpCodes/Control/CALL_L.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Control/CALL_L.json
@@ -58,8 +58,8 @@
                 "nextInstruction": "PUSH0"
               },
               {
-                "instructionPointer": 5,
-                "nextInstruction": "RET"
+                "instructionPointer": 0,
+                "nextInstruction": "CALL_L"
               }
             ]
           }
@@ -82,8 +82,8 @@
                 ]
               },
               {
-                "instructionPointer": 5,
-                "nextInstruction": "RET",
+                "instructionPointer": 0,
+                "nextInstruction": "CALL_L",
                 "evaluationStack": [
                   {
                     "type": "integer",

--- a/tests/neo-vm.Tests/Tests/Others/Debugger.json
+++ b/tests/neo-vm.Tests/Tests/Others/Debugger.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "category": "Others",
   "name": "Debugger",
   "tests": [
@@ -63,8 +63,8 @@
                 ]
               },
               {
-                "instructionPointer": 3,
-                "nextInstruction": "PUSH3",
+                "instructionPointer": 1,
+                "nextInstruction": "CALL",
                 "evaluationStack": [
                   {
                     "type": "integer",
@@ -97,8 +97,8 @@
                 ]
               },
               {
-                "instructionPointer": 3,
-                "nextInstruction": "PUSH3",
+                "instructionPointer": 1,
+                "nextInstruction": "CALL",
                 "evaluationStack": [
                   {
                     "type": "integer",

--- a/tests/neo-vm.Tests/Tests/Others/InvocationLimits.json
+++ b/tests/neo-vm.Tests/Tests/Others/InvocationLimits.json
@@ -94,8 +94,8 @@
                 ]
               },
               {
-                "instructionPointer": 16,
-                "nextInstruction": "RET",
+                "instructionPointer": 14,
+                "nextInstruction": "CALL",
                 "staticFields": [
                   {
                     "type": "integer",


### PR DESCRIPTION
Old: Move to next instruction before `RET`.
Now: Move to next instruction after `RET`.