### PR TITLE
Add OnExecutionStart

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1,4 +1,4 @@
-using Neo.VM.Types;
+﻿using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -127,6 +127,7 @@ namespace Neo.VM
 
         public VMState Execute()
         {
+            OnExecutionStart();
             if (State == VMState.BREAK)
                 State = VMState.NONE;
             while (State != VMState.HALT && State != VMState.FAULT)
@@ -1405,6 +1406,10 @@ namespace Neo.VM
             };
             LoadContext(context);
             return context;
+        }
+
+        protected virtual void OnExecutionStart()
+        {
         }
 
         protected virtual void OnFault(Exception e)


### PR DESCRIPTION
For time travel debugging, the trace capture ApplicationEngine needs to capture engine state at start of execution. This can be done in PreExecuteInstruction, but requires tracking state to ensure this initial trace is only captured once. Having an overridable OnExecutionStart method called at the start of execution would simplify this logic. 