### PR TITLE
Add TryGetInterface and GetInterfaceName to InteropInterface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,4 +14,4 @@ root = true
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,4 +14,4 @@ root = true
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf

--- a/src/neo-vm/Types/InteropInterface.cs
+++ b/src/neo-vm/Types/InteropInterface.cs
@@ -37,5 +37,22 @@ namespace Neo.VM.Types
             if (_object is T t) return t;
             throw new InvalidCastException();
         }
+
+        public bool TryGetInterface<T>(out T value)
+        {
+            if (_object is T t)
+            {
+                value = t;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public string GetInterfaceName()
+        {
+            return _object.GetType().FullName;
+        }
     }
 }


### PR DESCRIPTION
These two methods are for use by the debugger.

* GetInterfaceName returns the full type name of the object inside the InteropInterface. It will be used to show type information about an InteropInterface instance in the variables window of the debugger.
* TryGetInterface provides a no-throw way to retrieve the underlying object from an InteropInterface instance 