### PR TITLE
EvaluationStack implement IReadOnlyList

### DIFF
--- a/src/neo-vm/EvaluationStack.cs
+++ b/src/neo-vm/EvaluationStack.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace Neo.VM
 {
-    public sealed class EvaluationStack : IReadOnlyCollection<StackItem>
+    public sealed class EvaluationStack : IReadOnlyList<StackItem>
     {
         private readonly List<StackItem> innerList = new List<StackItem>();
         private readonly ReferenceCounter referenceCounter;
@@ -64,6 +64,8 @@ namespace Neo.VM
             }
             return innerList[innerList.Count - index - 1];
         }
+
+        StackItem IReadOnlyList<StackItem>.this[int index] => Peek(index);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Push(StackItem item)


### PR DESCRIPTION
Changes EvaluationStack to implement IReadOnlyList<StackItem> instead of IReadOnlyCollection<StackItem>. IReadOnlyList indexer simply calls existing Peek method.

This change is needed to simplify the trace debugger.