### PR TITLE
Fix UNPACK

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -969,6 +969,7 @@ namespace Neo.VM
                         for (int i = array.Count - 1; i >= 0; i--)
                             Push(array[i]);
                         Push(array.Count);
+                        array.Clear();
                         break;
                     }
                 case OpCode.NEWARRAY0:


### PR DESCRIPTION
VMArray poped by opcode `UNPACK` should be cleared to refresh the `ReferenceCounter`.