### PR TITLE
Allow to Create context without load

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1371,7 +1371,7 @@ namespace Neo.VM
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ExecutionContext CreateContext(Script script, int initialPosition = 0)
+        protected ExecutionContext CreateContext(Script script, int initialPosition = 0)
         {
             return new ExecutionContext(script, ReferenceCounter)
             {

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1370,6 +1370,7 @@ namespace Neo.VM
             CurrentContext = context;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ExecutionContext CreateContext(Script script, int initialPosition = 0)
         {
             return new ExecutionContext(script, ReferenceCounter)

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1370,12 +1370,17 @@ namespace Neo.VM
             CurrentContext = context;
         }
 
-        public ExecutionContext LoadScript(Script script, int initialPosition = 0)
+        public ExecutionContext CreateContext(Script script, int initialPosition = 0)
         {
-            ExecutionContext context = new ExecutionContext(script, ReferenceCounter)
+            return new ExecutionContext(script, ReferenceCounter)
             {
                 InstructionPointer = initialPosition
             };
+        }
+
+        public ExecutionContext LoadScript(Script script, int initialPosition = 0)
+        {
+            ExecutionContext context = CreateContext(script, initialPosition);
             LoadContext(context);
             return context;
         }


### PR DESCRIPTION
This allow us to configure the `ExecutionContextState` before trigger `protected override void LoadContext(ExecutionContext context)`