### PR TITLE
Add load and set opcodes for slots

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -523,6 +523,11 @@ namespace Neo.VM
                         ExecuteLoadFromSlot(CurrentContext.StaticFields, instruction.TokenU8);
                         break;
                     }
+                case OpCode.LDSFLDN:
+                    {
+                        ExecuteLoadFromSlot(CurrentContext.StaticFields, (int)CurrentContext.EvaluationStack.Pop().GetInteger());
+                        break;
+                    }
                 case OpCode.STSFLD0:
                 case OpCode.STSFLD1:
                 case OpCode.STSFLD2:
@@ -537,6 +542,11 @@ namespace Neo.VM
                 case OpCode.STSFLD:
                     {
                         ExecuteStoreToSlot(CurrentContext.StaticFields, instruction.TokenU8);
+                        break;
+                    }
+                case OpCode.STSFLDN:
+                    {
+                        ExecuteStoreToSlot(CurrentContext.StaticFields, (int)CurrentContext.EvaluationStack.Pop().GetInteger());
                         break;
                     }
                 case OpCode.LDLOC0:
@@ -555,6 +565,11 @@ namespace Neo.VM
                         ExecuteLoadFromSlot(CurrentContext.LocalVariables, instruction.TokenU8);
                         break;
                     }
+                case OpCode.LDLOCN:
+                    {
+                        ExecuteLoadFromSlot(CurrentContext.LocalVariables, (int)CurrentContext.EvaluationStack.Pop().GetInteger());
+                        break;
+                    }
                 case OpCode.STLOC0:
                 case OpCode.STLOC1:
                 case OpCode.STLOC2:
@@ -569,6 +584,11 @@ namespace Neo.VM
                 case OpCode.STLOC:
                     {
                         ExecuteStoreToSlot(CurrentContext.LocalVariables, instruction.TokenU8);
+                        break;
+                    }
+                case OpCode.STLOCN:
+                    {
+                        ExecuteStoreToSlot(CurrentContext.LocalVariables, (int)CurrentContext.EvaluationStack.Pop().GetInteger());
                         break;
                     }
                 case OpCode.LDARG0:
@@ -587,6 +607,11 @@ namespace Neo.VM
                         ExecuteLoadFromSlot(CurrentContext.Arguments, instruction.TokenU8);
                         break;
                     }
+                case OpCode.LDARGN:
+                    {
+                        ExecuteLoadFromSlot(CurrentContext.Arguments, (int)CurrentContext.EvaluationStack.Pop().GetInteger());
+                        break;
+                    }
                 case OpCode.STARG0:
                 case OpCode.STARG1:
                 case OpCode.STARG2:
@@ -601,6 +626,11 @@ namespace Neo.VM
                 case OpCode.STARG:
                     {
                         ExecuteStoreToSlot(CurrentContext.Arguments, instruction.TokenU8);
+                        break;
+                    }
+                case OpCode.STSFLDN:
+                    {
+                        ExecuteStoreToSlot(CurrentContext.Arguments, (int)CurrentContext.EvaluationStack.Pop().GetInteger());
                         break;
                     }
 

--- a/src/neo-vm/OpCode.cs
+++ b/src/neo-vm/OpCode.cs
@@ -389,170 +389,194 @@ namespace Neo.VM
         [OperandSize(Size = 1)]
         LDSFLD = 0x5F,
         /// <summary>
+        /// A value n is taken from top of main stack. Loads the static field at the specified index n onto the evaluation stack.
+        /// </summary>
+        LDSFLDN = 0x60,
+        /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at index 0.
         /// </summary>
-        STSFLD0 = 0x60,
+        STSFLD0 = 0x61,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at index 1.
         /// </summary>
-        STSFLD1 = 0x61,
+        STSFLD1 = 0x62,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at index 2.
         /// </summary>
-        STSFLD2 = 0x62,
+        STSFLD2 = 0x63,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at index 3.
         /// </summary>
-        STSFLD3 = 0x63,
+        STSFLD3 = 0x64,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at index 4.
         /// </summary>
-        STSFLD4 = 0x64,
+        STSFLD4 = 0x65,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at index 5.
         /// </summary>
-        STSFLD5 = 0x65,
+        STSFLD5 = 0x66,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at index 6.
         /// </summary>
-        STSFLD6 = 0x66,
+        STSFLD6 = 0x67,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the static field list at a specified index. The index is represented as a 1-byte unsigned integer.
         /// </summary>
         [OperandSize(Size = 1)]
-        STSFLD = 0x67,
+        STSFLD = 0x68,
+        /// <summary>
+        /// A value n is taken from top of main stack. Stores the value on top of the evaluation stack in the static field list at index n.
+        /// </summary>
+        LDSFLDN = 0x69,
         /// <summary>
         /// Loads the local variable at index 0 onto the evaluation stack.
         /// </summary>
-        LDLOC0 = 0x68,
+        LDLOC0 = 0x6A,
         /// <summary>
         /// Loads the local variable at index 1 onto the evaluation stack.
         /// </summary>
-        LDLOC1 = 0x69,
+        LDLOC1 = 0x6B,
         /// <summary>
         /// Loads the local variable at index 2 onto the evaluation stack.
         /// </summary>
-        LDLOC2 = 0x6A,
+        LDLOC2 = 0x6C,
         /// <summary>
         /// Loads the local variable at index 3 onto the evaluation stack.
         /// </summary>
-        LDLOC3 = 0x6B,
+        LDLOC3 = 0x6D,
         /// <summary>
         /// Loads the local variable at index 4 onto the evaluation stack.
         /// </summary>
-        LDLOC4 = 0x6C,
+        LDLOC4 = 0x6E,
         /// <summary>
         /// Loads the local variable at index 5 onto the evaluation stack.
         /// </summary>
-        LDLOC5 = 0x6D,
+        LDLOC5 = 0x6F,
         /// <summary>
         /// Loads the local variable at index 6 onto the evaluation stack.
         /// </summary>
-        LDLOC6 = 0x6E,
+        LDLOC6 = 0x70,
         /// <summary>
         /// Loads the local variable at a specified index onto the evaluation stack. The index is represented as a 1-byte unsigned integer.
         /// </summary>
         [OperandSize(Size = 1)]
         LDLOC = 0x6F,
         /// <summary>
+        /// A value n is taken from top of main stack. Loads the local variable at index n onto the evaluation stack.
+        /// </summary>
+        LDLOCN = 0x70,
+        /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at index 0.
         /// </summary>
-        STLOC0 = 0x70,
+        STLOC0 = 0x71,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at index 1.
         /// </summary>
-        STLOC1 = 0x71,
+        STLOC1 = 0x72,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at index 2.
         /// </summary>
-        STLOC2 = 0x72,
+        STLOC2 = 0x73,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at index 3.
         /// </summary>
-        STLOC3 = 0x73,
+        STLOC3 = 0x74,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at index 4.
         /// </summary>
-        STLOC4 = 0x74,
+        STLOC4 = 0x75,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at index 5.
         /// </summary>
-        STLOC5 = 0x75,
+        STLOC5 = 0x76,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at index 6.
         /// </summary>
-        STLOC6 = 0x76,
+        STLOC6 = 0x77,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the local variable list at a specified index. The index is represented as a 1-byte unsigned integer.
         /// </summary>
         [OperandSize(Size = 1)]
-        STLOC = 0x77,
+        STLOC = 0x78,
+        /// <summary>
+        /// A value n is taken from top of main stack. Stores the value on top of the evaluation stack in the local variable list at index n.
+        /// </summary>
+        STLOCN = 0x79,
         /// <summary>
         /// Loads the argument at index 0 onto the evaluation stack.
         /// </summary>
-        LDARG0 = 0x78,
+        LDARG0 = 0x7A,
         /// <summary>
         /// Loads the argument at index 1 onto the evaluation stack.
         /// </summary>
-        LDARG1 = 0x79,
+        LDARG1 = 0x7B,
         /// <summary>
         /// Loads the argument at index 2 onto the evaluation stack.
         /// </summary>
-        LDARG2 = 0x7A,
+        LDARG2 = 0x7C,
         /// <summary>
         /// Loads the argument at index 3 onto the evaluation stack.
         /// </summary>
-        LDARG3 = 0x7B,
+        LDARG3 = 0x7D,
         /// <summary>
         /// Loads the argument at index 4 onto the evaluation stack.
         /// </summary>
-        LDARG4 = 0x7C,
+        LDARG4 = 0x7E,
         /// <summary>
         /// Loads the argument at index 5 onto the evaluation stack.
         /// </summary>
-        LDARG5 = 0x7D,
+        LDARG5 = 0x7F,
         /// <summary>
         /// Loads the argument at index 6 onto the evaluation stack.
         /// </summary>
-        LDARG6 = 0x7E,
+        LDARG6 = 0x80,
         /// <summary>
         /// Loads the argument at a specified index onto the evaluation stack. The index is represented as a 1-byte unsigned integer.
         /// </summary>
         [OperandSize(Size = 1)]
-        LDARG = 0x7F,
+        LDARG = 0x81,
+        /// <summary>
+        /// A value n is taken from top of main stack. Loads the argument at index n onto the evaluation stack.
+        /// </summary>
+        LDARGN = 0x82,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at index 0.
         /// </summary>
-        STARG0 = 0x80,
+        STARG0 = 0x83,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at index 1.
         /// </summary>
-        STARG1 = 0x81,
+        STARG1 = 0x84,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at index 2.
         /// </summary>
-        STARG2 = 0x82,
+        STARG2 = 0x85,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at index 3.
         /// </summary>
-        STARG3 = 0x83,
+        STARG3 = 0x86,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at index 4.
         /// </summary>
-        STARG4 = 0x84,
+        STARG4 = 0x87,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at index 5.
         /// </summary>
-        STARG5 = 0x85,
+        STARG5 = 0x88,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at index 6.
         /// </summary>
-        STARG6 = 0x86,
+        STARG6 = 0x89,
         /// <summary>
         /// Stores the value on top of the evaluation stack in the argument slot at a specified index. The index is represented as a 1-byte unsigned integer.
         /// </summary>
         [OperandSize(Size = 1)]
-        STARG = 0x87,
+        STARG = 0x8A,
+        /// <summary>
+        /// A value n is taken from top of main stack. Stores the value on top of the evaluation stack in the argument slot at index n.
+        /// </summary>
+        STARGN = 0x8B,
 
         #endregion
 


### PR DESCRIPTION
This PR adds OpCodes for loading and setting slots using numbers that are popped from the eval stack instead of from bytecode operands. This will allow slots to be get/set dynamically at runtime instead of slot indexes being determined at compile-time.

We ran into an issue while upgrading our NEO•ONE TypeScript compiler from Neo2 to Neo3. We were using the alt stack in Neo3 to keep track of a program's scope. Since there is no longer an alt stack we sought to use the new static fields to keep track of current scope in the program. But we need a way to evaluate which static fields to load and set at runtime, which is where the idea for these new opcodes came in. We implement a sort of stack using the static fields by using the static field 0 to track the "top" of our stack. So static field index 0 is always an integer stack item that holds the static field index which represents the top of our stack. These new opcodes will allow us to use the static fields as a sort of stack by retrieving the current "top" from index 0 and using that as an argument for loading or setting scope into a static field.

We really need a solution for tracking scope in our compiler and this seems to be the best solution. We're open to suggestions on how to solve our problem. Otherwise we really need something like this for our compiler.

https://github.com/neo-project/neo/issues/2171
@danwbyrne