### PR TITLE
Fix CALLT

### DIFF
--- a/src/neo-vm/ExecutionContext.cs
+++ b/src/neo-vm/ExecutionContext.cs
@@ -12,11 +12,6 @@ namespace Neo.VM
         private int instructionPointer;
 
         /// <summary>
-        /// Number of parameters
-        /// </summary>
-        public ushort ParametersCount { get; }
-
-        /// <summary>
         /// Number of items to be returned
         /// </summary>
         public int RVCount { get; }
@@ -86,17 +81,16 @@ namespace Neo.VM
         /// </summary>
         /// <param name="script">Script</param>
         /// <param name="rvcount">Number of items to be returned</param>
-        internal ExecutionContext(Script script, ushort pcount, int rvcount, ReferenceCounter referenceCounter)
-            : this(new SharedStates(script, referenceCounter), pcount, rvcount, 0)
+        internal ExecutionContext(Script script, int rvcount, ReferenceCounter referenceCounter)
+            : this(new SharedStates(script, referenceCounter), rvcount, 0)
         {
         }
 
-        private ExecutionContext(SharedStates shared_states, ushort pcount, int rvcount, int initialPosition)
+        private ExecutionContext(SharedStates shared_states, int rvcount, int initialPosition)
         {
             if (rvcount < -1 || rvcount > ushort.MaxValue)
                 throw new ArgumentOutOfRangeException(nameof(rvcount));
             this.shared_states = shared_states;
-            this.ParametersCount = pcount;
             this.RVCount = rvcount;
             this.InstructionPointer = initialPosition;
         }
@@ -108,7 +102,7 @@ namespace Neo.VM
 
         public ExecutionContext Clone(int initialPosition)
         {
-            return new ExecutionContext(shared_states, 0, 0, initialPosition);
+            return new ExecutionContext(shared_states, 0, initialPosition);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -301,7 +301,6 @@ namespace Neo.VM
                     }
                 case OpCode.CALLT:
                     {
-                        ExecutionContext context_current = CurrentContext;
                         LoadToken(instruction.TokenU16);
                         break;
                     }
@@ -1389,17 +1388,17 @@ namespace Neo.VM
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected ExecutionContext CreateContext(Script script, ushort pcount, int rvcount, int initialPosition)
+        protected ExecutionContext CreateContext(Script script, int rvcount, int initialPosition)
         {
-            return new ExecutionContext(script, pcount, rvcount, ReferenceCounter)
+            return new ExecutionContext(script, rvcount, ReferenceCounter)
             {
                 InstructionPointer = initialPosition
             };
         }
 
-        public ExecutionContext LoadScript(Script script, ushort pcount = 0, int rvcount = -1, int initialPosition = 0)
+        public ExecutionContext LoadScript(Script script, int rvcount = -1, int initialPosition = 0)
         {
-            ExecutionContext context = CreateContext(script, pcount, rvcount, initialPosition);
+            ExecutionContext context = CreateContext(script, rvcount, initialPosition);
             LoadContext(context);
             return context;
         }

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -302,8 +302,7 @@ namespace Neo.VM
                 case OpCode.CALLT:
                     {
                         ExecutionContext context_current = CurrentContext;
-                        ExecutionContext context_loaded = LoadToken(instruction.TokenU16);
-                        context_current.EvaluationStack.MoveTo(context_loaded.EvaluationStack, context_loaded.ParametersCount);
+                        LoadToken(instruction.TokenU16);
                         break;
                     }
                 case OpCode.ABORT:

--- a/tests/neo-vm.Tests/UtExecutionContext.cs
+++ b/tests/neo-vm.Tests/UtExecutionContext.cs
@@ -11,7 +11,7 @@ namespace Neo.Test
         [TestMethod]
         public void StateTest()
         {
-            var context = new ExecutionContext(Array.Empty<byte>(), 0, -1, new ReferenceCounter());
+            var context = new ExecutionContext(Array.Empty<byte>(), -1, new ReferenceCounter());
 
             var stack = context.GetState<Stack<int>>();
             Assert.AreEqual(0, stack.Count);


### PR DESCRIPTION
Arguments are already loaded in `LoadToken`

https://github.com/neo-project/neo/blob/6129c3bd619e68ca142aec4c3eff57bf939c63a5/src/neo/SmartContract/ApplicationEngine.cs#L210-L212

Required for https://github.com/neo-project/neo-devpack-dotnet/pull/420/