### PR TITLE
Fix `ReferenceCounter` corner cases

### DIFF
--- a/src/neo-vm/ReferenceCounter.cs
+++ b/src/neo-vm/ReferenceCounter.cs
@@ -106,8 +106,9 @@ namespace Neo.VM
                     foreach (CompoundType subitem in compound.SubItems.OfType<CompoundType>())
                     {
                         if (toBeDestroyed.Contains(subitem)) continue;
+                        if (!counter.ContainsKey(subitem)) continue;
                         Entry entry = counter[subitem];
-                        entry.ObjectReferences.Remove(compound);
+                        entry.ObjectReferences?.Remove(compound);
                         if (entry.StackReferences == 0)
                             zero_referred.Add(subitem);
                     }


### PR DESCRIPTION
We're working on our TypeScript smart contract compiler and we seem to have hit two corner case errors. It's quite difficult to try to trace/log exactly what's going on with all the CompoundType items our compiler creates and how they are managed in the `ReferenceCounter`. But this change fixes those corner cases.

Two two corner cases are:

- A key not found error [here](https://github.com/neo-project/neo-vm/blob/59b8ac73d285aa9d607aee53eeadde82fcba9324/src/neo-vm/ReferenceCounter.cs#L109). From our logging it appears that `subitem` is being removed from `counter` before it gets here.
- A null reference error [here](https://github.com/neo-project/neo-vm/blob/59b8ac73d285aa9d607aee53eeadde82fcba9324/src/neo-vm/ReferenceCounter.cs#L110) where `entry.ObjectReferences` is null. Not sure how this happens.

Let us know if these changes are unacceptable. We're not sure if these corner cases are something we need to fix in our compiler or not. We've been looking at this problem for a bit and aren't quite sure what to do.

@ndhuutai