### PR TITLE
Bitwise operation of `OpCode.BOOLAND` and `OpCode.BOOLOR` Throw exception if divisor of `OpCode.DIV` is zero.

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -833,6 +833,7 @@ namespace Neo.VM
                     {
                         var x2 = Pop().GetInteger();
                         var x1 = Pop().GetInteger();
+                        if (x2.IsZero) throw new InvalidOperationException($"The value {x2} is out of range.");
                         Push(x1 / x2);
                         break;
                     }
@@ -884,14 +885,14 @@ namespace Neo.VM
                     {
                         var x2 = Pop().GetBoolean();
                         var x1 = Pop().GetBoolean();
-                        Push(x1 && x2);
+                        Push(x1 & x2);
                         break;
                     }
                 case OpCode.BOOLOR:
                     {
                         var x2 = Pop().GetBoolean();
                         var x1 = Pop().GetBoolean();
-                        Push(x1 || x2);
+                        Push(x1 | x2);
                         break;
                     }
                 case OpCode.NZ:


### PR DESCRIPTION
`true | true`

|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.0177 ns | 0.0172 ns | 0.0315 ns | 0.0000 ns |
| Instruction_BOOLAND_Bit | 0.0000 ns | 0.0000 ns | 0.0000 ns | 0.0000 ns |
|      Instruction_BOOLOR | 0.2387 ns | 0.0204 ns | 0.0191 ns | 0.2403 ns |
|  Instruction_BOOLOR_Bit | 0.0022 ns | 0.0033 ns | 0.0029 ns | 0.0006 ns |

`false | true`

|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.2717 ns | 0.0087 ns | 0.0072 ns | 0.2733 ns |
| Instruction_BOOLAND_Bit | 0.0042 ns | 0.0089 ns | 0.0083 ns | 0.0000 ns |
|      Instruction_BOOLOR | 0.0009 ns | 0.0039 ns | 0.0036 ns | 0.0000 ns |
|  Instruction_BOOLOR_Bit | 0.0189 ns | 0.0115 ns | 0.0107 ns | 0.0214 ns |

`true | false`

|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.0019 ns | 0.0054 ns | 0.0048 ns | 0.0000 ns |
| Instruction_BOOLAND_Bit | 0.0066 ns | 0.0088 ns | 0.0078 ns | 0.0022 ns |
|      Instruction_BOOLOR | 0.2428 ns | 0.0213 ns | 0.0188 ns | 0.2388 ns |
|  Instruction_BOOLOR_Bit | 0.0034 ns | 0.0058 ns | 0.0054 ns | 0.0000 ns |

`false | false`

|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.2832 ns | 0.0164 ns | 0.0145 ns | 0.2868 ns |
| Instruction_BOOLAND_Bit | 0.0000 ns | 0.0000 ns | 0.0000 ns | 0.0000 ns |
|      Instruction_BOOLOR | 0.0002 ns | 0.0008 ns | 0.0012 ns | 0.0000 ns |
|  Instruction_BOOLOR_Bit | 0.0085 ns | 0.0089 ns | 0.0084 ns | 0.0067 ns |