### PR TITLE
Bitwise the operations of `OpCode.BOOLAND` and `OpCode.BOOLOR`.

### DIFF
--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -833,6 +833,7 @@ namespace Neo.VM
                     {
                         var x2 = Pop().GetInteger();
                         var x1 = Pop().GetInteger();
+                        if (x2.IsZero) throw new InvalidOperationException($"The value {x2} is out of range.");
                         Push(x1 / x2);
                         break;
                     }
@@ -884,14 +885,14 @@ namespace Neo.VM
                     {
                         var x2 = Pop().GetBoolean();
                         var x1 = Pop().GetBoolean();
-                        Push(x1 && x2);
+                        Push(x1 & x2);
                         break;
                     }
                 case OpCode.BOOLOR:
                     {
                         var x2 = Pop().GetBoolean();
                         var x1 = Pop().GetBoolean();
-                        Push(x1 || x2);
+                        Push(x1 | x2);
                         break;
                     }
                 case OpCode.NZ:

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1273,6 +1273,8 @@ namespace Neo.VM
                     {
                         VMArray x = Pop<VMArray>();
                         int index = x.Count - 1;
+                        if (index < 0)
+                            throw new InvalidOperationException($"The value {index} is out of range.");
                         Push(x[index]);
                         x.RemoveAt(index);
                         break;

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -1272,8 +1272,6 @@ namespace Neo.VM
                     {
                         VMArray x = Pop<VMArray>();
                         int index = x.Count - 1;
-                        if (index < 0)
-                            throw new InvalidOperationException($"The value {index} is out of range.");
                         Push(x[index]);
                         x.RemoveAt(index);
                         break;

--- a/tests/neo-vm.Tests/UtEvaluationStack.cs
+++ b/tests/neo-vm.Tests/UtEvaluationStack.cs
@@ -4,6 +4,7 @@ using Neo.VM.Types;
 using System;
 using System.Collections;
 using System.Linq;
+using System.Numerics;
 
 namespace Neo.Test
 {
@@ -186,6 +187,18 @@ namespace Neo.Test
             Assert.IsTrue(stack.Pop<Integer>().Equals(2));
             Assert.IsTrue(stack.Pop<Integer>().Equals(1));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => stack.Pop<Integer>().Equals(0));
+        }
+
+
+        [TestMethod]
+        public void TestOpCodeBOOL_Bitwise()
+        {
+            var a = true;
+            var b = false;
+
+            Assert.AreEqual(a&&b, a & b);
+            Assert.AreEqual(a || b, a | b);
+
         }
     }
 }

--- a/tests/neo-vm.Tests/UtEvaluationStack.cs
+++ b/tests/neo-vm.Tests/UtEvaluationStack.cs
@@ -4,7 +4,6 @@ using Neo.VM.Types;
 using System;
 using System.Collections;
 using System.Linq;
-using System.Numerics;
 
 namespace Neo.Test
 {

--- a/tests/neo-vm.Tests/UtEvaluationStack.cs
+++ b/tests/neo-vm.Tests/UtEvaluationStack.cs
@@ -188,16 +188,14 @@ namespace Neo.Test
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => stack.Pop<Integer>().Equals(0));
         }
 
-
         [TestMethod]
         public void TestOpCodeBOOL_Bitwise()
         {
             var a = true;
             var b = false;
 
-            Assert.AreEqual(a&&b, a & b);
+            Assert.AreEqual(a && b, a & b);
             Assert.AreEqual(a || b, a | b);
-
         }
     }
 }


### PR DESCRIPTION
BenchmarkDotNet=v0.13.0, OS=macOS Big Sur 11.4 (20F71) [Darwin 20.5.0]
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=5.0.302
  [Host]     : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT  [AttachedDebugger]
  DefaultJob : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT

`true | true`

|                  Method |      Mean |     Error |    StdDev |    Median |
|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.0177 ns | 0.0172 ns | 0.0315 ns | 0.0000 ns |
| Instruction_BOOLAND_Bit | 0.0000 ns | 0.0000 ns | 0.0000 ns | 0.0000 ns |
|      Instruction_BOOLOR | 0.2387 ns | 0.0204 ns | 0.0191 ns | 0.2403 ns |
|  Instruction_BOOLOR_Bit | 0.0022 ns | 0.0033 ns | 0.0029 ns | 0.0006 ns |


`false | true`

|                  Method |      Mean |     Error |    StdDev |    Median |
|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.2717 ns | 0.0087 ns | 0.0072 ns | 0.2733 ns |
| Instruction_BOOLAND_Bit | 0.0042 ns | 0.0089 ns | 0.0083 ns | 0.0000 ns |
|      Instruction_BOOLOR | 0.0009 ns | 0.0039 ns | 0.0036 ns | 0.0000 ns |
|  Instruction_BOOLOR_Bit | 0.0189 ns | 0.0115 ns | 0.0107 ns | 0.0214 ns |

`true | false`

|                  Method |      Mean |     Error |    StdDev |    Median |
|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.0019 ns | 0.0054 ns | 0.0048 ns | 0.0000 ns |
| Instruction_BOOLAND_Bit | 0.0066 ns | 0.0088 ns | 0.0078 ns | 0.0022 ns |
|      Instruction_BOOLOR | 0.2428 ns | 0.0213 ns | 0.0188 ns | 0.2388 ns |
|  Instruction_BOOLOR_Bit | 0.0034 ns | 0.0058 ns | 0.0054 ns | 0.0000 ns |

`false | false`

|                  Method |      Mean |     Error |    StdDev |    Median |
|------------------------ |----------:|----------:|----------:|----------:|
|     Instruction_BOOLAND | 0.2832 ns | 0.0164 ns | 0.0145 ns | 0.2868 ns |
| Instruction_BOOLAND_Bit | 0.0000 ns | 0.0000 ns | 0.0000 ns | 0.0000 ns |
|      Instruction_BOOLOR | 0.0002 ns | 0.0008 ns | 0.0012 ns | 0.0000 ns |
|  Instruction_BOOLOR_Bit | 0.0085 ns | 0.0089 ns | 0.0084 ns | 0.0067 ns |
