### PR TITLE
Add a test for ENDFINALLY without ENDTRY

### DIFF
--- a/tests/neo-vm.Tests/Tests/OpCodes/Control/TRY_CATCH_FINALLY10.json
+++ b/tests/neo-vm.Tests/Tests/OpCodes/Control/TRY_CATCH_FINALLY10.json
@@ -1,0 +1,26 @@
+{
+	"category": "Control",
+	"name": "TRY_CATCH_FINALLY",
+	"tests": [
+	  {
+		"name": "try + finally without ENDTRY",
+		"script": [
+		  "TRY",
+		  "0x0003",
+		  "ENDFINALLY"
+		],
+		"steps": [
+		  {
+			"actions": [
+			  "stepInto",
+			  "stepInto"
+			],
+			"result": {
+			  "state": "FAULT"
+			}
+		  }
+		]
+	  }
+	]
+  }
+  


### PR DESCRIPTION
See https://github.com/nspcc-dev/neo-go/pull/2396 , C# node behaves correctly.

Signed-off-by: Evgenii Stratonikov <evgenii@nspcc.ru>