### PR TITLE
Optimize Buffer: uses ArrayPool

### DIFF
--- a/src/neo-vm.Benchmarks/Benchmarks.cs
+++ b/src/neo-vm.Benchmarks/Benchmarks.cs
@@ -70,6 +70,22 @@ namespace Neo.VM
             Run(nameof(NeoVMIssue418), "whBNEcARTRHAVgEB/gGdYBFNEU0SwFMSwFhKJPNFUUU=");
         }
 
+        public static void NeoIssue2723()
+        {
+            // L00: INITSSLOT 1
+            // L01: PUSHINT32 130000
+            // L02: STSFLD 0
+            // L03: PUSHINT32 1048576
+            // L04: NEWBUFFER
+            // L05: DROP
+            // L06: LDSFLD 0
+            // L07: DEC
+            // L08: DUP
+            // L09: STSFLD 0
+            // L10: JMPIF L03
+            Run(nameof(NeoIssue2723), "VgEC0PsBAGcAAgAAEACIRV8AnUpnACTz");
+        }
+
         private static void Run(string name, string poc)
         {
             byte[] script = Convert.FromBase64String(poc);

--- a/src/neo-vm/ExecutionEngine.cs
+++ b/src/neo-vm/ExecutionEngine.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using Array = System.Array;
 using Buffer = Neo.VM.Types.Buffer;
 using VMArray = Neo.VM.Types.Array;
 
@@ -686,7 +685,7 @@ namespace Neo.VM
                         Buffer dst = Pop<Buffer>();
                         if (checked(di + count) > dst.Size)
                             throw new InvalidOperationException($"The value {count} is out of range.");
-                        src.Slice(si, count).CopyTo(dst.InnerBuffer.AsSpan(di));
+                        src.Slice(si, count).CopyTo(dst.InnerBuffer.Span[di..]);
                         break;
                     }
                 case OpCode.CAT:
@@ -696,8 +695,8 @@ namespace Neo.VM
                         int length = x1.Length + x2.Length;
                         Limits.AssertMaxItemSize(length);
                         Buffer result = new(length, false);
-                        x1.CopyTo(result.InnerBuffer);
-                        x2.CopyTo(result.InnerBuffer.AsSpan(x1.Length));
+                        x1.CopyTo(result.InnerBuffer.Span);
+                        x2.CopyTo(result.InnerBuffer.Span[x1.Length..]);
                         Push(result);
                         break;
                     }
@@ -713,7 +712,7 @@ namespace Neo.VM
                         if (index + count > x.Length)
                             throw new InvalidOperationException($"The value {count} is out of range.");
                         Buffer result = new(count, false);
-                        x.Slice(index, count).CopyTo(result.InnerBuffer);
+                        x.Slice(index, count).CopyTo(result.InnerBuffer.Span);
                         Push(result);
                         break;
                     }
@@ -726,7 +725,7 @@ namespace Neo.VM
                         if (count > x.Length)
                             throw new InvalidOperationException($"The value {count} is out of range.");
                         Buffer result = new(count, false);
-                        x[..count].CopyTo(result.InnerBuffer);
+                        x[..count].CopyTo(result.InnerBuffer.Span);
                         Push(result);
                         break;
                     }
@@ -739,7 +738,7 @@ namespace Neo.VM
                         if (count > x.Length)
                             throw new InvalidOperationException($"The value {count} is out of range.");
                         Buffer result = new(count, false);
-                        x[^count..^0].CopyTo(result.InnerBuffer);
+                        x[^count..^0].CopyTo(result.InnerBuffer.Span);
                         Push(result);
                         break;
                     }
@@ -1245,7 +1244,7 @@ namespace Neo.VM
                                     int index = (int)key.GetInteger();
                                     if (index < 0 || index >= buffer.Size)
                                         throw new CatchableException($"The value {index} is out of range.");
-                                    Push((BigInteger)buffer.InnerBuffer[index]);
+                                    Push((BigInteger)buffer.InnerBuffer.Span[index]);
                                     break;
                                 }
                             default:
@@ -1292,7 +1291,7 @@ namespace Neo.VM
                                     int b = (int)p.GetInteger();
                                     if (b < sbyte.MinValue || b > byte.MaxValue)
                                         throw new InvalidOperationException($"Overflow in {instruction.OpCode}, {b} is not a byte type.");
-                                    buffer.InnerBuffer[index] = (byte)b;
+                                    buffer.InnerBuffer.Span[index] = (byte)b;
                                     break;
                                 }
                             default:
@@ -1309,7 +1308,7 @@ namespace Neo.VM
                                 array.Reverse();
                                 break;
                             case Buffer buffer:
-                                Array.Reverse(buffer.InnerBuffer);
+                                buffer.InnerBuffer.Span.Reverse();
                                 break;
                             default:
                                 throw new InvalidOperationException($"Invalid type for {instruction.OpCode}: {x.Type}");

--- a/src/neo-vm/Types/Buffer.cs
+++ b/src/neo-vm/Types/Buffer.cs
@@ -19,7 +19,7 @@ namespace Neo.VM.Types
     /// <summary>
     /// Represents a memory block that can be used for reading and writing in the VM.
     /// </summary>
-    [DebuggerDisplay("Type={GetType().Name}, Value={System.BitConverter.ToString(GetSpan().ToArray()).Replace(\"-\", string.Empty)}")]
+    [DebuggerDisplay("Type={GetType().Name}, Value={System.Convert.ToHexString(GetSpan().ToArray())}")]
     public class Buffer : StackItem
     {
         /// <summary>

--- a/src/neo-vm/Types/Buffer.cs
+++ b/src/neo-vm/Types/Buffer.cs
@@ -9,6 +9,7 @@
 // modifications are permitted.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
@@ -24,13 +25,16 @@ namespace Neo.VM.Types
         /// <summary>
         /// The internal byte array used to store the actual data.
         /// </summary>
-        public readonly byte[] InnerBuffer;
+        public readonly Memory<byte> InnerBuffer;
 
         /// <summary>
         /// The size of the buffer.
         /// </summary>
         public int Size => InnerBuffer.Length;
         public override StackItemType Type => StackItemType.Buffer;
+
+        private readonly byte[] _buffer;
+        private bool _keep_alive = false;
 
         /// <summary>
         /// Create a buffer of the specified size.
@@ -39,19 +43,29 @@ namespace Neo.VM.Types
         /// <param name="zeroInitialize">Indicates whether the created buffer is zero-initialized.</param>
         public Buffer(int size, bool zeroInitialize = true)
         {
-            InnerBuffer = zeroInitialize
-                ? new byte[size]
-                : GC.AllocateUninitializedArray<byte>(size);
+            _buffer = ArrayPool<byte>.Shared.Rent(size);
+            InnerBuffer = new Memory<byte>(_buffer, 0, size);
+            if (zeroInitialize) InnerBuffer.Span.Clear();
         }
 
         /// <summary>
         /// Create a buffer with the specified data.
         /// </summary>
         /// <param name="data">The data to be contained in this buffer.</param>
-        public Buffer(ReadOnlySpan<byte> data)
+        public Buffer(ReadOnlySpan<byte> data) : this(data.Length, false)
         {
-            InnerBuffer = GC.AllocateUninitializedArray<byte>(data.Length);
-            if (!data.IsEmpty) data.CopyTo(InnerBuffer);
+            data.CopyTo(InnerBuffer.Span);
+        }
+
+        internal override void Cleanup()
+        {
+            if (!_keep_alive)
+                ArrayPool<byte>.Shared.Return(_buffer, clearArray: false);
+        }
+
+        public void KeepAlive()
+        {
+            _keep_alive = true;
         }
 
         public override StackItem ConvertTo(StackItemType type)
@@ -61,10 +75,10 @@ namespace Neo.VM.Types
                 case StackItemType.Integer:
                     if (InnerBuffer.Length > Integer.MaxSize)
                         throw new InvalidCastException();
-                    return new BigInteger(InnerBuffer);
+                    return new BigInteger(InnerBuffer.Span);
                 case StackItemType.ByteString:
                     byte[] clone = GC.AllocateUninitializedArray<byte>(InnerBuffer.Length);
-                    InnerBuffer.CopyTo(clone.AsSpan());
+                    InnerBuffer.CopyTo(clone);
                     return clone;
                 default:
                     return base.ConvertTo(type);
@@ -74,7 +88,7 @@ namespace Neo.VM.Types
         internal override StackItem DeepCopy(Dictionary<StackItem, StackItem> refMap)
         {
             if (refMap.TryGetValue(this, out StackItem? mappedItem)) return mappedItem;
-            Buffer result = new(InnerBuffer);
+            Buffer result = new(InnerBuffer.Span);
             refMap.Add(this, result);
             return result;
         }
@@ -86,7 +100,7 @@ namespace Neo.VM.Types
 
         public override ReadOnlySpan<byte> GetSpan()
         {
-            return InnerBuffer;
+            return InnerBuffer.Span;
         }
     }
 }

--- a/src/neo-vm/Types/Buffer.cs
+++ b/src/neo-vm/Types/Buffer.cs
@@ -19,7 +19,7 @@ namespace Neo.VM.Types
     /// <summary>
     /// Represents a memory block that can be used for reading and writing in the VM.
     /// </summary>
-    [DebuggerDisplay("Type={GetType().Name}, Value={System.BitConverter.ToString(InnerBuffer).Replace(\"-\", string.Empty)}")]
+    [DebuggerDisplay("Type={GetType().Name}, Value={System.BitConverter.ToString(GetSpan().ToArray()).Replace(\"-\", string.Empty)}")]
     public class Buffer : StackItem
     {
         /// <summary>

--- a/src/neo-vm/Types/StackItem.cs
+++ b/src/neo-vm/Types/StackItem.cs
@@ -59,6 +59,10 @@ namespace Neo.VM.Types
             throw new InvalidCastException();
         }
 
+        internal virtual void Cleanup()
+        {
+        }
+
         /// <summary>
         /// Copy the object and all its children.
         /// </summary>

--- a/tests/neo-vm.Tests/VMJsonTestBase.cs
+++ b/tests/neo-vm.Tests/VMJsonTestBase.cs
@@ -240,7 +240,7 @@ namespace Neo.Test
                 case VM.Types.Boolean v: value = new JValue(v.GetBoolean()); break;
                 case VM.Types.Integer v: value = new JValue(v.GetInteger().ToString()); break;
                 case VM.Types.ByteString v: value = new JValue(v.GetSpan().ToArray()); break;
-                case VM.Types.Buffer v: value = new JValue(v.InnerBuffer); break;
+                case VM.Types.Buffer v: value = new JValue(v.InnerBuffer.ToArray()); break;
                 //case VM.Types.Struct v:
                 case VM.Types.Array v:
                     {


### PR DESCRIPTION
1. Used `ArrayPool` to optimize the performance of `Buffer`.
2. Added a new benchmark: NeoIssue2723. The iteration number is changed to `130000`, which consumes about 10GAS at default settings.

Close neo-project/neo#2723