### PR TITLE
Add ABORTMSG & ASSERTMSG

### DIFF
--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -1371,7 +1371,19 @@ namespace Neo.VM
                         Push(x.ConvertTo((StackItemType)instruction.TokenU8));
                         break;
                     }
-
+                case OpCode.ABORTMSG:
+                    {
+                        var msg = Pop().GetString();
+                        throw new Exception($"{OpCode.ABORTMSG} is executed. Reason: {msg}");
+                    }
+                case OpCode.ASSERTMSG:
+                    {
+                        var msg = Pop().GetString();
+                        var x = Pop().GetBoolean();
+                        if (!x)
+                            throw new Exception($"{OpCode.ASSERTMSG} is executed with false result. Reason: {msg}");
+                        break;
+                    }
                 default: throw new InvalidOperationException($"Opcode {instruction.OpCode} is undefined.");
             }
         }

--- a/src/Neo.VM/OpCode.cs
+++ b/src/Neo.VM/OpCode.cs
@@ -878,5 +878,14 @@ namespace Neo.VM
         CONVERT = 0xDB,
 
         #endregion
+
+        /// <summary>
+        /// Turns the vm state to FAULT immediately, and cannot be caught. Includes a reason
+        /// </summary>
+        ABORTMSG = 0xE0,
+        /// <summary>
+        /// Pop the top value of the stack, if it false, then exit vm execution and set vm state to FAULT. Includes a reason
+        /// </summary>
+        ASSERTMSG = 0xE1
     }
 }

--- a/src/Neo.VM/OpCode.cs
+++ b/src/Neo.VM/OpCode.cs
@@ -887,6 +887,8 @@ namespace Neo.VM
 
         #endregion
 
+        #region Extensions
+
         /// <summary>
         /// Turns the vm state to FAULT immediately, and cannot be caught. Includes a reason
         /// </summary>
@@ -895,5 +897,7 @@ namespace Neo.VM
         /// Pop the top value of the stack, if it false, then exit vm execution and set vm state to FAULT. Includes a reason
         /// </summary>
         ASSERTMSG = 0xE1
+
+        #endregion
     }
 }

--- a/tests/Neo.VM.Tests/Tests/OpCodes/Control/ABORTMSG.json
+++ b/tests/Neo.VM.Tests/Tests/OpCodes/Control/ABORTMSG.json
@@ -1,0 +1,25 @@
+{
+  "category": "Control",
+  "name": "ABORTMSG",
+  "tests": [
+    {
+      "name": "Basic Test",
+      "script": [
+        "PUSHDATA1",
+        "0x03",
+        "0x4e454f",
+        "ABORTMSG"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "FAULT"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Neo.VM.Tests/Tests/OpCodes/Control/ABORTMSG.json
+++ b/tests/Neo.VM.Tests/Tests/OpCodes/Control/ABORTMSG.json
@@ -16,7 +16,8 @@
             "execute"
           ],
           "result": {
-            "state": "FAULT"
+            "state": "FAULT",
+            "exceptionMessage": "ABORTMSG is executed. Reason: NEO"
           }
         }
       ]

--- a/tests/Neo.VM.Tests/Tests/OpCodes/Control/ASSERTMSG.json
+++ b/tests/Neo.VM.Tests/Tests/OpCodes/Control/ASSERTMSG.json
@@ -1,0 +1,46 @@
+{
+  "category": "Control",
+  "name": "ASSERTMSG",
+  "tests": [
+    {
+      "name": "Fault Test",
+      "script": [
+        "PUSH0",
+        "PUSHDATA1",
+        "0x04",
+        "0x4641494c",
+        "ASSERTMSG"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "FAULT"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Halt Test",
+      "script": [
+        "PUSH1",
+        "PUSHDATA1",
+        "0x04",
+        "0x50415353",
+        "ASSERTMSG"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Neo.VM.Tests/Tests/OpCodes/Control/ASSERTMSG.json
+++ b/tests/Neo.VM.Tests/Tests/OpCodes/Control/ASSERTMSG.json
@@ -17,7 +17,8 @@
             "execute"
           ],
           "result": {
-            "state": "FAULT"
+            "state": "FAULT",
+            "exceptionMessage": "ASSERTMSG is executed with false result. Reason: FAIL"
           }
         }
       ]

--- a/tests/Neo.VM.Tests/Types/TestEngine.cs
+++ b/tests/Neo.VM.Tests/Types/TestEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using Neo.VM;
 using Neo.VM.Types;
 
@@ -5,6 +6,8 @@ namespace Neo.Test.Types
 {
     class TestEngine : ExecutionEngine
     {
+        public Exception FaultException { get; private set; }
+
         protected override void OnSysCall(uint method)
         {
             if (method == 0x77777777)
@@ -21,5 +24,12 @@ namespace Neo.Test.Types
 
             throw new System.Exception();
         }
+
+        protected override void OnFault(Exception ex)
+        {
+            FaultException = ex;
+            base.OnFault(ex);
+        }
+
     }
 }

--- a/tests/Neo.VM.Tests/Types/TestEngine.cs
+++ b/tests/Neo.VM.Tests/Types/TestEngine.cs
@@ -30,6 +30,5 @@ namespace Neo.Test.Types
             FaultException = ex;
             base.OnFault(ex);
         }
-
     }
 }

--- a/tests/Neo.VM.Tests/Types/VMUTExecutionEngineState.cs
+++ b/tests/Neo.VM.Tests/Types/VMUTExecutionEngineState.cs
@@ -4,7 +4,8 @@ using Newtonsoft.Json;
 
 namespace Neo.Test.Types
 {
-    public class VMUTExecutionEngineState
+    public class
+        VMUTExecutionEngineState
     {
         [JsonProperty, JsonConverter(typeof(UppercaseEnum))]
         public VMState State { get; set; }
@@ -14,5 +15,9 @@ namespace Neo.Test.Types
 
         [JsonProperty]
         public VMUTExecutionContextState[] InvocationStack { get; set; }
+
+        [JsonProperty]
+        public string ExceptionMessage { get; set; }
+
     }
 }

--- a/tests/Neo.VM.Tests/Types/VMUTExecutionEngineState.cs
+++ b/tests/Neo.VM.Tests/Types/VMUTExecutionEngineState.cs
@@ -4,8 +4,7 @@ using Newtonsoft.Json;
 
 namespace Neo.Test.Types
 {
-    public class
-        VMUTExecutionEngineState
+    public class VMUTExecutionEngineState
     {
         [JsonProperty, JsonConverter(typeof(UppercaseEnum))]
         public VMState State { get; set; }
@@ -18,6 +17,5 @@ namespace Neo.Test.Types
 
         [JsonProperty]
         public string ExceptionMessage { get; set; }
-
     }
 }

--- a/tests/Neo.VM.Tests/VMJsonTestBase.cs
+++ b/tests/Neo.VM.Tests/VMJsonTestBase.cs
@@ -66,10 +66,17 @@ namespace Neo.Test
         /// <param name="engine">Engine</param>
         /// <param name="result">Result</param>
         /// <param name="message">Message</param>
-        private void AssertResult(VMUTExecutionEngineState result, ExecutionEngine engine, string message)
+        private void AssertResult(VMUTExecutionEngineState result, TestEngine engine, string message)
         {
             AssertAreEqual(result.State.ToString().ToLowerInvariant(), engine.State.ToString().ToLowerInvariant(), message + "State is different");
-            if (engine.State == VMState.FAULT) return;
+            if (engine.State == VMState.FAULT)
+            {
+                if (result.ExceptionMessage != null)
+                {
+                    AssertAreEqual(result.ExceptionMessage, engine.FaultException.Message, message + " [Exception]");
+                }
+                return;
+            }
             AssertResult(result.InvocationStack, engine.InvocationStack, message + " [Invocation stack]");
             AssertResult(result.ResultStack, engine.ResultStack, message + " [Result stack] ");
         }


### PR DESCRIPTION
See https://github.com/neo-project/neo/issues/2782#issuecomment-1259504674
I think there's a big upside in supporting this in terms of improved developer experience by having actual feedback on why the ABORT or ASSERT failed. Hence why I'm trying to keep this going

For example [the reason(s)](https://github.com/nspcc-dev/neo-go/blob/3dbd36ef70c902ace1552b849a00a454a3fad73b/examples/nft-d/nft.go#L362-L377) why sending funds to this NFT fails can actually be communicated back to the user without having to run a node yourself in order to be able to read the logs