### PR TITLE
Support .NET Standard 2.1 and .NET 5.0

### DIFF
--- a/src/Neo.VM/Collections/OrderedDictionary.cs
+++ b/src/Neo.VM/Collections/OrderedDictionary.cs
@@ -39,7 +39,7 @@ namespace Neo.VM.Collections
             }
         }
 
-        private readonly InternalCollection collection = new();
+        private readonly InternalCollection collection = new InternalCollection();
 
         public int Count => collection.Count;
         public bool IsReadOnly => false;

--- a/src/Neo.VM/Collections/OrderedDictionary.cs
+++ b/src/Neo.VM/Collections/OrderedDictionary.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -76,7 +76,10 @@ namespace Neo.VM.Collections
             return collection.Remove(key);
         }
 
+// supress warning of value parameter nullability mismatch
+#pragma warning disable CS8767
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767
         {
             if (collection.TryGetValue(key, out var entry))
             {

--- a/src/Neo.VM/Collections/OrderedDictionary.cs
+++ b/src/Neo.VM/Collections/OrderedDictionary.cs
@@ -76,7 +76,7 @@ namespace Neo.VM.Collections
             return collection.Remove(key);
         }
 
-// supress warning of value parameter nullability mismatch
+        // supress warning of value parameter nullability mismatch
 #pragma warning disable CS8767
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
 #pragma warning restore CS8767

--- a/src/Neo.VM/Cryptography/BitOperations.cs
+++ b/src/Neo.VM/Cryptography/BitOperations.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2015-2022 The Neo Project.
+//
+// The neo is free software distributed under the MIT software license,
+// see the accompanying file LICENSE in the main directory of the
+// project or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Neo.VM.Cryptography
+{
+#if !NET5_0_OR_GREATER
+    static class BitOperations
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint RotateLeft(uint value, int offset)
+            => (value << offset) | (value >> (32 - offset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong RotateLeft(ulong value, int offset)
+            => (value << offset) | (value >> (64 - offset));
+    }
+#endif
+}

--- a/src/Neo.VM/Debugger.cs
+++ b/src/Neo.VM/Debugger.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -18,7 +18,7 @@ namespace Neo.VM
     public class Debugger
     {
         private readonly ExecutionEngine engine;
-        private readonly Dictionary<Script, HashSet<uint>> break_points = new();
+        private readonly Dictionary<Script, HashSet<uint>> break_points = new Dictionary<Script, HashSet<uint>>();
 
         /// <summary>
         /// Create a debugger on the specified <see cref="ExecutionEngine"/>.

--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -22,7 +22,7 @@ namespace Neo.VM
     /// </summary>
     public sealed class EvaluationStack : IReadOnlyList<StackItem>
     {
-        private readonly List<StackItem> innerList = new();
+        private readonly List<StackItem> innerList = new List<StackItem>();
         private readonly ReferenceCounter referenceCounter;
 
         internal EvaluationStack(ReferenceCounter referenceCounter)

--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -152,11 +152,14 @@ namespace Neo.VM
                     throw new ArgumentOutOfRangeException(nameof(index));
             }
             index = innerList.Count - index - 1;
-            if (innerList[index] is not T item)
-                throw new InvalidCastException($"The item can't be casted to type {typeof(T)}");
-            innerList.RemoveAt(index);
-            referenceCounter.RemoveStackReference(item);
-            return item;
+            if (innerList[index] is T item)
+            {
+                innerList.RemoveAt(index);
+                referenceCounter.RemoveStackReference(item);
+                return item;
+            }
+
+            throw new InvalidCastException($"The item can't be casted to type {typeof(T)}");
         }
     }
 }

--- a/src/Neo.VM/EvaluationStack.cs
+++ b/src/Neo.VM/EvaluationStack.cs
@@ -152,14 +152,11 @@ namespace Neo.VM
                     throw new ArgumentOutOfRangeException(nameof(index));
             }
             index = innerList.Count - index - 1;
-            if (innerList[index] is T item)
-            {
-                innerList.RemoveAt(index);
-                referenceCounter.RemoveStackReference(item);
-                return item;
-            }
-
-            throw new InvalidCastException($"The item can't be casted to type {typeof(T)}");
+            if (!(innerList[index] is T item))
+                throw new InvalidCastException($"The item can't be casted to type {typeof(T)}");
+            innerList.RemoveAt(index);
+            referenceCounter.RemoveStackReference(item);
+            return item;
         }
     }
 }

--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -1285,13 +1285,18 @@ namespace Neo.VM
                                     int index = (int)key.GetInteger();
                                     if (index < 0 || index >= buffer.Size)
                                         throw new CatchableException($"The value {index} is out of range.");
-                                    if (value is not PrimitiveType p)
+                                    if (value is PrimitiveType p)
+                                    {
+                                        int b = (int)p.GetInteger();
+                                        if (b < sbyte.MinValue || b > byte.MaxValue)
+                                            throw new InvalidOperationException($"Overflow in {instruction.OpCode}, {b} is not a byte type.");
+                                        buffer.InnerBuffer.Span[index] = (byte)b;
+                                        break;
+                                    }
+                                    else
+                                    {
                                         throw new InvalidOperationException($"Value must be a primitive type in {instruction.OpCode}");
-                                    int b = (int)p.GetInteger();
-                                    if (b < sbyte.MinValue || b > byte.MaxValue)
-                                        throw new InvalidOperationException($"Overflow in {instruction.OpCode}, {b} is not a byte type.");
-                                    buffer.InnerBuffer.Span[index] = (byte)b;
-                                    break;
+                                    }
                                 }
                             default:
                                 throw new InvalidOperationException($"Invalid type for {instruction.OpCode}: {x.Type}");

--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -1295,18 +1295,13 @@ namespace Neo.VM
                                     int index = (int)key.GetInteger();
                                     if (index < 0 || index >= buffer.Size)
                                         throw new CatchableException($"The value {index} is out of range.");
-                                    if (value is PrimitiveType p)
-                                    {
-                                        int b = (int)p.GetInteger();
-                                        if (b < sbyte.MinValue || b > byte.MaxValue)
-                                            throw new InvalidOperationException($"Overflow in {instruction.OpCode}, {b} is not a byte type.");
-                                        buffer.InnerBuffer.Span[index] = (byte)b;
-                                        break;
-                                    }
-                                    else
-                                    {
+                                    if (!(value is PrimitiveType p))
                                         throw new InvalidOperationException($"Value must be a primitive type in {instruction.OpCode}");
-                                    }
+                                    int b = (int)p.GetInteger();
+                                    if (b < sbyte.MinValue || b > byte.MaxValue)
+                                        throw new InvalidOperationException($"Overflow in {instruction.OpCode}, {b} is not a byte type.");
+                                    buffer.InnerBuffer.Span[index] = (byte)b;
+                                    break;
                                 }
                             default:
                                 throw new InvalidOperationException($"Invalid type for {instruction.OpCode}: {x.Type}");

--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -693,7 +693,7 @@ namespace Neo.VM
                         var x1 = Pop().GetSpan();
                         int length = x1.Length + x2.Length;
                         Limits.AssertMaxItemSize(length);
-                        Buffer result = new(length, false);
+                        Buffer result = new Buffer(length, false);
                         x1.CopyTo(result.InnerBuffer.Span);
                         x2.CopyTo(result.InnerBuffer.Span[x1.Length..]);
                         Push(result);
@@ -710,7 +710,7 @@ namespace Neo.VM
                         var x = Pop().GetSpan();
                         if (index + count > x.Length)
                             throw new InvalidOperationException($"The value {count} is out of range.");
-                        Buffer result = new(count, false);
+                        Buffer result = new Buffer(count, false);
                         x.Slice(index, count).CopyTo(result.InnerBuffer.Span);
                         Push(result);
                         break;
@@ -723,7 +723,7 @@ namespace Neo.VM
                         var x = Pop().GetSpan();
                         if (count > x.Length)
                             throw new InvalidOperationException($"The value {count} is out of range.");
-                        Buffer result = new(count, false);
+                        Buffer result = new Buffer(count, false);
                         x[..count].CopyTo(result.InnerBuffer.Span);
                         Push(result);
                         break;
@@ -736,7 +736,7 @@ namespace Neo.VM
                         var x = Pop().GetSpan();
                         if (count > x.Length)
                             throw new InvalidOperationException($"The value {count} is out of range.");
-                        Buffer result = new(count, false);
+                        Buffer result = new Buffer(count, false);
                         x[^count..^0].CopyTo(result.InnerBuffer.Span);
                         Push(result);
                         break;
@@ -1010,7 +1010,7 @@ namespace Neo.VM
                         int size = (int)Pop().GetInteger();
                         if (size < 0 || size * 2 > CurrentContext!.EvaluationStack.Count)
                             throw new InvalidOperationException($"The value {size} is out of range.");
-                        Map map = new(ReferenceCounter);
+                        Map map = new Map(ReferenceCounter);
                         for (int i = 0; i < size; i++)
                         {
                             PrimitiveType key = Pop<PrimitiveType>();
@@ -1025,7 +1025,7 @@ namespace Neo.VM
                         int size = (int)Pop().GetInteger();
                         if (size < 0 || size > CurrentContext!.EvaluationStack.Count)
                             throw new InvalidOperationException($"The value {size} is out of range.");
-                        Struct @struct = new(ReferenceCounter);
+                        Struct @struct = new Struct(ReferenceCounter);
                         for (int i = 0; i < size; i++)
                         {
                             StackItem item = Pop();
@@ -1039,7 +1039,7 @@ namespace Neo.VM
                         int size = (int)Pop().GetInteger();
                         if (size < 0 || size > CurrentContext!.EvaluationStack.Count)
                             throw new InvalidOperationException($"The value {size} is out of range.");
-                        VMArray array = new(ReferenceCounter);
+                        VMArray array = new VMArray(ReferenceCounter);
                         for (int i = 0; i < size; i++)
                         {
                             StackItem item = Pop();
@@ -1114,7 +1114,7 @@ namespace Neo.VM
                         int n = (int)Pop().GetInteger();
                         if (n < 0 || n > Limits.MaxStackSize)
                             throw new InvalidOperationException($"MaxStackSize exceed: {n}");
-                        Struct result = new(ReferenceCounter);
+                        Struct result = new Struct(ReferenceCounter);
                         for (var i = 0; i < n; i++)
                             result.Add(StackItem.Null);
                         Push(result);
@@ -1199,7 +1199,7 @@ namespace Neo.VM
                             Map map => map.Values,
                             _ => throw new InvalidOperationException($"Invalid type for {instruction.OpCode}: {x.Type}"),
                         };
-                        VMArray newArray = new(ReferenceCounter);
+                        VMArray newArray = new VMArray(ReferenceCounter);
                         foreach (StackItem item in values)
                             if (item is Struct s)
                                 newArray.Add(s.Clone(Limits));

--- a/src/Neo.VM/ExecutionEngineLimits.cs
+++ b/src/Neo.VM/ExecutionEngineLimits.cs
@@ -26,7 +26,9 @@ namespace Neo.VM
         /// <summary>
         /// The maximum number of bits that <see cref="OpCode.SHL"/> and <see cref="OpCode.SHR"/> can shift.
         /// </summary>
-        public int MaxShift { get;
+        public int MaxShift
+        {
+            get;
 #if NET5_0_OR_GREATER
             init;
 #else
@@ -37,7 +39,9 @@ namespace Neo.VM
         /// <summary>
         /// The maximum number of items that can be contained in the VM's evaluation stacks and slots.
         /// </summary>
-        public uint MaxStackSize { get;
+        public uint MaxStackSize
+        {
+            get;
 #if NET5_0_OR_GREATER
             init;
 #else
@@ -48,7 +52,9 @@ namespace Neo.VM
         /// <summary>
         /// The maximum size of an item in the VM.
         /// </summary>
-        public uint MaxItemSize { get;
+        public uint MaxItemSize
+        {
+            get;
 #if NET5_0_OR_GREATER
             init;
 #else
@@ -59,7 +65,9 @@ namespace Neo.VM
         /// <summary>
         /// The largest comparable size. If a <see cref="Types.ByteString"/> or <see cref="Types.Struct"/> exceeds this size, comparison operations on it cannot be performed in the VM.
         /// </summary>
-        public uint MaxComparableSize { get;
+        public uint MaxComparableSize
+        {
+            get;
 #if NET5_0_OR_GREATER
             init;
 #else
@@ -70,7 +78,9 @@ namespace Neo.VM
         /// <summary>
         /// The maximum number of frames in the invocation stack of the VM.
         /// </summary>
-        public uint MaxInvocationStackSize { get;
+        public uint MaxInvocationStackSize
+        {
+            get;
 #if NET5_0_OR_GREATER
             init;
 #else
@@ -81,7 +91,9 @@ namespace Neo.VM
         /// <summary>
         /// The maximum nesting depth of <see langword="try"/>-<see langword="catch"/>-<see langword="finally"/> blocks.
         /// </summary>
-        public uint MaxTryNestingDepth { get;
+        public uint MaxTryNestingDepth
+        {
+            get;
 #if NET5_0_OR_GREATER
             init;
 #else
@@ -92,7 +104,9 @@ namespace Neo.VM
         /// <summary>
         /// Allow to catch the ExecutionEngine Exceptions
         /// </summary>
-        public bool CatchEngineExceptions { get;
+        public bool CatchEngineExceptions
+        {
+            get;
 #if NET5_0_OR_GREATER
             init;
 #else

--- a/src/Neo.VM/ExecutionEngineLimits.cs
+++ b/src/Neo.VM/ExecutionEngineLimits.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -16,47 +16,89 @@ namespace Neo.VM
     /// <summary>
     /// Represents the restrictions on the VM.
     /// </summary>
-    public sealed record ExecutionEngineLimits
+    public sealed class ExecutionEngineLimits : IEquatable<ExecutionEngineLimits>
     {
         /// <summary>
         /// The default strategy.
         /// </summary>
-        public static readonly ExecutionEngineLimits Default = new();
+        public static readonly ExecutionEngineLimits Default = new ExecutionEngineLimits();
 
         /// <summary>
         /// The maximum number of bits that <see cref="OpCode.SHL"/> and <see cref="OpCode.SHR"/> can shift.
         /// </summary>
-        public int MaxShift { get; init; } = 256;
+        public int MaxShift { get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            set;
+#endif
+        } = 256;
 
         /// <summary>
         /// The maximum number of items that can be contained in the VM's evaluation stacks and slots.
         /// </summary>
-        public uint MaxStackSize { get; init; } = 2 * 1024;
+        public uint MaxStackSize { get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            set;
+#endif
+        } = 2 * 1024;
 
         /// <summary>
         /// The maximum size of an item in the VM.
         /// </summary>
-        public uint MaxItemSize { get; init; } = 1024 * 1024;
+        public uint MaxItemSize { get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            set;
+#endif
+        } = 1024 * 1024;
 
         /// <summary>
         /// The largest comparable size. If a <see cref="Types.ByteString"/> or <see cref="Types.Struct"/> exceeds this size, comparison operations on it cannot be performed in the VM.
         /// </summary>
-        public uint MaxComparableSize { get; init; } = 65536;
+        public uint MaxComparableSize { get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            set;
+#endif
+        } = 65536;
 
         /// <summary>
         /// The maximum number of frames in the invocation stack of the VM.
         /// </summary>
-        public uint MaxInvocationStackSize { get; init; } = 1024;
+        public uint MaxInvocationStackSize { get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            set;
+#endif
+        } = 1024;
 
         /// <summary>
         /// The maximum nesting depth of <see langword="try"/>-<see langword="catch"/>-<see langword="finally"/> blocks.
         /// </summary>
-        public uint MaxTryNestingDepth { get; init; } = 16;
+        public uint MaxTryNestingDepth { get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            set;
+#endif
+        } = 16;
 
         /// <summary>
         /// Allow to catch the ExecutionEngine Exceptions
         /// </summary>
-        public bool CatchEngineExceptions { get; init; } = true;
+        public bool CatchEngineExceptions { get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            set;
+#endif
+        } = true;
 
         /// <summary>
         /// Assert that the size of the item meets the limit.
@@ -82,6 +124,20 @@ namespace Neo.VM
             {
                 throw new InvalidOperationException($"Invalid shift value: {shift}");
             }
+        }
+
+        public bool Equals(ExecutionEngineLimits? other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            if (other is null) return false;
+            return MaxShift == other.MaxShift
+                && MaxStackSize == other.MaxStackSize
+                && MaxItemSize == other.MaxItemSize
+                && MaxComparableSize == other.MaxComparableSize
+                && MaxInvocationStackSize == other.MaxInvocationStackSize
+                && MaxInvocationStackSize == other.MaxInvocationStackSize
+                && MaxTryNestingDepth == other.MaxTryNestingDepth
+                && CatchEngineExceptions == other.CatchEngineExceptions;
         }
     }
 }

--- a/src/Neo.VM/Instruction.cs
+++ b/src/Neo.VM/Instruction.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -191,7 +191,7 @@ namespace Neo.VM
         private Instruction(OpCode opcode)
         {
             this.OpCode = opcode;
-            if (!Enum.IsDefined(opcode)) throw new BadScriptException();
+            if (!Enum.IsDefined(typeof(OpCode), opcode)) throw new BadScriptException();
         }
 
         internal Instruction(ReadOnlyMemory<byte> script, int ip) : this((OpCode)script.Span[ip++])

--- a/src/Neo.VM/Neo.VM.csproj
+++ b/src/Neo.VM/Neo.VM.csproj
@@ -5,7 +5,7 @@
     <Description>Neo virtual machine</Description>
     <VersionPrefix>3.4.0</VersionPrefix>
     <Authors>The Neo Project</Authors>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
     <PackageTags>NEO;AntShares;Blockchain;Smart Contract;VM</PackageTags>
     <PackageProjectUrl>https://github.com/neo-project/neo-vm</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -23,8 +23,8 @@ namespace Neo.VM
     {
         private const bool TrackAllItems = false;
 
-        private readonly HashSet<StackItem> tracked_items = new(ReferenceEqualityComparer.Instance);
-        private readonly HashSet<StackItem> zero_referred = new(ReferenceEqualityComparer.Instance);
+        private readonly HashSet<StackItem> tracked_items = new HashSet<StackItem>(ReferenceEqualityComparer.Instance);
+        private readonly HashSet<StackItem> zero_referred = new HashSet<StackItem>(ReferenceEqualityComparer.Instance);
         private LinkedList<HashSet<StackItem>>? cached_components;
         private int references_count = 0;
 
@@ -49,10 +49,10 @@ namespace Neo.VM
             if (!NeedTrack(item)) return;
             cached_components = null;
             tracked_items.Add(item);
-            item.ObjectReferences ??= new(ReferenceEqualityComparer.Instance);
+            item.ObjectReferences ??= new Dictionary<CompoundType, StackItem.ObjectReferenceEntry>(ReferenceEqualityComparer.Instance);
             if (!item.ObjectReferences.TryGetValue(parent, out var pEntry))
             {
-                pEntry = new(parent);
+                pEntry = new StackItem.ObjectReferenceEntry(parent);
                 item.ObjectReferences.Add(parent, pEntry);
             }
             pEntry.References++;
@@ -84,7 +84,7 @@ namespace Neo.VM
                 if (cached_components is null)
                 {
                     //Tarjan<StackItem> tarjan = new(tracked_items.Where(p => p.StackReferences == 0));
-                    Tarjan tarjan = new(tracked_items);
+                    Tarjan tarjan = new Tarjan(tracked_items);
                     cached_components = tarjan.Invoke();
                 }
                 foreach (StackItem item in tracked_items)

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -39,7 +39,8 @@ namespace Neo.VM
 #pragma warning disable CS0162
             if (TrackAllItems) return true;
 #pragma warning restore CS0162
-            if (item is CompoundType or Buffer) return true;
+            if (item is CompoundType) return true;
+            if (item is Buffer) return true;
             return false;
         }
 

--- a/src/Neo.VM/ReferenceEqualityComparer.cs
+++ b/src/Neo.VM/ReferenceEqualityComparer.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2016-2022 The Neo Project.
+//
+// The neo-vm is free software distributed under the MIT software license,
+// see the accompanying file LICENSE in the main directory of the
+// project or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Neo.VM
+{
+#if !NET5_0_OR_GREATER
+    // https://github.dev/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ReferenceEqualityComparer.cs
+    public sealed class ReferenceEqualityComparer : IEqualityComparer<object?>, System.Collections.IEqualityComparer
+    {
+        private ReferenceEqualityComparer() { }
+
+        public static ReferenceEqualityComparer Instance { get; } = new ReferenceEqualityComparer();
+
+        public new bool Equals(object? x, object? y)  => ReferenceEquals(x, y);
+
+        public int GetHashCode(object? obj) => RuntimeHelpers.GetHashCode(obj!);
+    }
+#endif
+}

--- a/src/Neo.VM/ReferenceEqualityComparer.cs
+++ b/src/Neo.VM/ReferenceEqualityComparer.cs
@@ -21,7 +21,7 @@ namespace Neo.VM
 
         public static ReferenceEqualityComparer Instance { get; } = new ReferenceEqualityComparer();
 
-        public new bool Equals(object? x, object? y)  => ReferenceEquals(x, y);
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
 
         public int GetHashCode(object? obj) => RuntimeHelpers.GetHashCode(obj!);
     }

--- a/src/Neo.VM/Script.cs
+++ b/src/Neo.VM/Script.cs
@@ -24,7 +24,7 @@ namespace Neo.VM
     {
         private readonly ReadOnlyMemory<byte> _value;
         private readonly bool strictMode;
-        private readonly Dictionary<int, Instruction> _instructions = new();
+        private readonly Dictionary<int, Instruction> _instructions = new Dictionary<int, Instruction>();
 
         /// <summary>
         /// The length of the script.
@@ -154,7 +154,7 @@ namespace Neo.VM
         }
 
         public static implicit operator ReadOnlyMemory<byte>(Script script) => script._value;
-        public static implicit operator Script(ReadOnlyMemory<byte> script) => new(script);
-        public static implicit operator Script(byte[] script) => new(script);
+        public static implicit operator Script(ReadOnlyMemory<byte> script) => new Script(script);
+        public static implicit operator Script(byte[] script) => new Script(script);
     }
 }

--- a/src/Neo.VM/ScriptBuilder.cs
+++ b/src/Neo.VM/ScriptBuilder.cs
@@ -97,12 +97,18 @@ namespace Neo.VM
             if (!value.TryWriteBytes(buffer, out int bytesWritten, isUnsigned: false, isBigEndian: false))
                 throw new ArgumentOutOfRangeException(nameof(value));
 
-            if (bytesWritten == 1) return Emit(OpCode.PUSHINT8, PadRight(buffer, bytesWritten, 1, value.Sign < 0));
-            if (bytesWritten == 2) return Emit(OpCode.PUSHINT16, PadRight(buffer, bytesWritten, 2, value.Sign < 0));
-            if (bytesWritten <= 4) return Emit(OpCode.PUSHINT32, PadRight(buffer, bytesWritten, 4, value.Sign < 0));
-            if (bytesWritten <= 8) return Emit(OpCode.PUSHINT64, PadRight(buffer, bytesWritten, 8, value.Sign < 0));
-            if (bytesWritten <= 16) return Emit(OpCode.PUSHINT128, PadRight(buffer, bytesWritten, 16, value.Sign < 0));
-            return Emit(OpCode.PUSHINT256, PadRight(buffer, bytesWritten, 32, value.Sign < 0));
+            return bytesWritten <= 8
+                ? bytesWritten > 4
+                    ? Emit(OpCode.PUSHINT64, PadRight(buffer, bytesWritten, 8, value.Sign < 0))
+                    : bytesWritten switch
+                    {
+                        1 => Emit(OpCode.PUSHINT8, PadRight(buffer, bytesWritten, 1, value.Sign < 0)),
+                        2 => Emit(OpCode.PUSHINT16, PadRight(buffer, bytesWritten, 2, value.Sign < 0)),
+                        _ => Emit(OpCode.PUSHINT32, PadRight(buffer, bytesWritten, 4, value.Sign < 0)),
+                    }
+                : bytesWritten > 16
+                    ? Emit(OpCode.PUSHINT256, PadRight(buffer, bytesWritten, 32, value.Sign < 0))
+                    : Emit(OpCode.PUSHINT128, PadRight(buffer, bytesWritten, 16, value.Sign < 0));
         }
 
         /// <summary>

--- a/src/Neo.VM/ScriptBuilder.cs
+++ b/src/Neo.VM/ScriptBuilder.cs
@@ -19,7 +19,7 @@ namespace Neo.VM
     /// </summary>
     public class ScriptBuilder : IDisposable
     {
-        private readonly MemoryStream ms = new();
+        private readonly MemoryStream ms = new MemoryStream();
         private readonly BinaryWriter writer;
 
         /// <summary>

--- a/src/Neo.VM/ScriptBuilder.cs
+++ b/src/Neo.VM/ScriptBuilder.cs
@@ -96,15 +96,13 @@ namespace Neo.VM
             Span<byte> buffer = stackalloc byte[32];
             if (!value.TryWriteBytes(buffer, out int bytesWritten, isUnsigned: false, isBigEndian: false))
                 throw new ArgumentOutOfRangeException(nameof(value));
-            return bytesWritten switch
-            {
-                1 => Emit(OpCode.PUSHINT8, PadRight(buffer, bytesWritten, 1, value.Sign < 0)),
-                2 => Emit(OpCode.PUSHINT16, PadRight(buffer, bytesWritten, 2, value.Sign < 0)),
-                <= 4 => Emit(OpCode.PUSHINT32, PadRight(buffer, bytesWritten, 4, value.Sign < 0)),
-                <= 8 => Emit(OpCode.PUSHINT64, PadRight(buffer, bytesWritten, 8, value.Sign < 0)),
-                <= 16 => Emit(OpCode.PUSHINT128, PadRight(buffer, bytesWritten, 16, value.Sign < 0)),
-                _ => Emit(OpCode.PUSHINT256, PadRight(buffer, bytesWritten, 32, value.Sign < 0)),
-            };
+
+            if (bytesWritten == 1) return Emit(OpCode.PUSHINT8, PadRight(buffer, bytesWritten, 1, value.Sign < 0));
+            if (bytesWritten == 2) return Emit(OpCode.PUSHINT16, PadRight(buffer, bytesWritten, 2, value.Sign < 0));
+            if (bytesWritten <= 4) return Emit(OpCode.PUSHINT32, PadRight(buffer, bytesWritten, 4, value.Sign < 0));
+            if (bytesWritten <= 8) return Emit(OpCode.PUSHINT64, PadRight(buffer, bytesWritten, 8, value.Sign < 0));
+            if (bytesWritten <= 16) return Emit(OpCode.PUSHINT128, PadRight(buffer, bytesWritten, 16, value.Sign < 0));
+            return Emit(OpCode.PUSHINT256, PadRight(buffer, bytesWritten, 32, value.Sign < 0));
         }
 
         /// <summary>

--- a/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
+++ b/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
@@ -17,8 +17,8 @@ namespace Neo.VM.StronglyConnectedComponents
     class Tarjan
     {
         private readonly IEnumerable<T> vertexs;
-        private readonly LinkedList<HashSet<T>> components = new();
-        private readonly Stack<T> stack = new();
+        private readonly LinkedList<HashSet<T>> components = new LinkedList<HashSet<T>>();
+        private readonly Stack<T> stack = new Stack<T>();
         private int index = 0;
 
         public Tarjan(IEnumerable<T> vertexs)
@@ -59,7 +59,7 @@ namespace Neo.VM.StronglyConnectedComponents
 
             if (v.LowLink == v.DFN)
             {
-                HashSet<T> scc = new(ReferenceEqualityComparer.Instance);
+                HashSet<T> scc = new HashSet<T>(ReferenceEqualityComparer.Instance);
                 T w;
                 do
                 {
@@ -73,7 +73,7 @@ namespace Neo.VM.StronglyConnectedComponents
 
         private void StrongConnectNonRecursive(T v)
         {
-            Stack<(T, T?, IEnumerator<T>?, int)> sstack = new();
+            Stack<(T, T?, IEnumerator<T>?, int)> sstack = new Stack<(T, T?, IEnumerator<T>?, int)>();
             sstack.Push((v, null, null, 0));
             while (sstack.TryPop(out var state))
             {
@@ -106,7 +106,7 @@ namespace Neo.VM.StronglyConnectedComponents
                         }
                         if (v.LowLink == v.DFN)
                         {
-                            HashSet<T> scc = new(ReferenceEqualityComparer.Instance);
+                            HashSet<T> scc = new HashSet<T>(ReferenceEqualityComparer.Instance);
                             do
                             {
                                 w = stack.Pop();

--- a/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
+++ b/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -77,7 +77,8 @@ namespace Neo.VM.StronglyConnectedComponents
             sstack.Push((v, null, null, 0));
             while (sstack.TryPop(out var state))
             {
-                (v, T? w, IEnumerator<T>? s, int n) = state;
+                v = state.Item1;
+                var (_, w, s, n) = state;
                 switch (n)
                 {
                     case 0:

--- a/src/Neo.VM/Types/Buffer.cs
+++ b/src/Neo.VM/Types/Buffer.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -77,7 +77,11 @@ namespace Neo.VM.Types
                         throw new InvalidCastException();
                     return new BigInteger(InnerBuffer.Span);
                 case StackItemType.ByteString:
+#if NET5_0_OR_GREATER
                     byte[] clone = GC.AllocateUninitializedArray<byte>(InnerBuffer.Length);
+#else
+                    byte[] clone = new byte[InnerBuffer.Length];
+#endif
                     InnerBuffer.CopyTo(clone);
                     return clone;
                 default:

--- a/src/Neo.VM/Types/Buffer.cs
+++ b/src/Neo.VM/Types/Buffer.cs
@@ -88,7 +88,9 @@ namespace Neo.VM.Types
         internal override StackItem DeepCopy(Dictionary<StackItem, StackItem> refMap, bool asImmutable)
         {
             if (refMap.TryGetValue(this, out StackItem? mappedItem)) return mappedItem;
-            StackItem result = asImmutable ? new ByteString(InnerBuffer.ToArray()) : new Buffer(InnerBuffer.Span);
+            StackItem result = asImmutable
+                ? (StackItem)new ByteString(InnerBuffer.ToArray())
+                : new Buffer(InnerBuffer.Span);
             refMap.Add(this, result);
             return result;
         }

--- a/src/Neo.VM/Types/ByteString.cs
+++ b/src/Neo.VM/Types/ByteString.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -51,8 +51,8 @@ namespace Neo.VM.Types
         public override bool Equals(StackItem? other)
         {
             if (ReferenceEquals(this, other)) return true;
-            if (other is not ByteString b) return false;
-            return Equals(b);
+            if (other is ByteString b) return Equals(b);
+            return false;
         }
 
         internal override bool Equals(StackItem? other, ExecutionEngineLimits limits)
@@ -68,12 +68,16 @@ namespace Neo.VM.Types
             uint comparedSize = 1;
             try
             {
-                if (other is not ByteString b) return false;
-                comparedSize = Math.Max((uint)Math.Max(Size, b.Size), comparedSize);
-                if (ReferenceEquals(this, b)) return true;
-                if (b.Size > limits)
-                    throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
-                return Equals(b);
+                if (other is ByteString b)
+                {
+                    comparedSize = Math.Max((uint)Math.Max(Size, b.Size), comparedSize);
+                    if (ReferenceEquals(this, b)) return true;
+                    if (b.Size > limits)
+                        throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
+                    return Equals(b);
+                }
+
+                return false;
             }
             finally
             {
@@ -91,7 +95,7 @@ namespace Neo.VM.Types
         {
             if (_hashCode == 0)
             {
-                using Murmur32 murmur = new(s_seed);
+                using Murmur32 murmur = new Murmur32(s_seed);
                 _hashCode = BinaryPrimitives.ReadInt32LittleEndian(murmur.ComputeHash(GetSpan().ToArray()));
             }
             return _hashCode;

--- a/src/Neo.VM/Types/ByteString.cs
+++ b/src/Neo.VM/Types/ByteString.cs
@@ -51,8 +51,8 @@ namespace Neo.VM.Types
         public override bool Equals(StackItem? other)
         {
             if (ReferenceEquals(this, other)) return true;
-            if (other is ByteString b) return Equals(b);
-            return false;
+            if (!(other is ByteString b)) return false;
+            return Equals(b);
         }
 
         internal override bool Equals(StackItem? other, ExecutionEngineLimits limits)
@@ -68,16 +68,12 @@ namespace Neo.VM.Types
             uint comparedSize = 1;
             try
             {
-                if (other is ByteString b)
-                {
-                    comparedSize = Math.Max((uint)Math.Max(Size, b.Size), comparedSize);
-                    if (ReferenceEquals(this, b)) return true;
-                    if (b.Size > limits)
-                        throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
-                    return Equals(b);
-                }
-
-                return false;
+                if (!(other is ByteString b)) return false;
+                comparedSize = Math.Max((uint)Math.Max(Size, b.Size), comparedSize);
+                if (ReferenceEquals(this, b)) return true;
+                if (b.Size > limits)
+                    throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
+                return Equals(b);
             }
             finally
             {

--- a/src/Neo.VM/Types/Map.cs
+++ b/src/Neo.VM/Types/Map.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -167,7 +167,10 @@ namespace Neo.VM.Types
         /// <see langword="true" /> if the map contains an element that has the specified key;
         /// otherwise, <see langword="false"/>.
         /// </returns>
+// supress warning of value parameter nullability mismatch
+#pragma warning disable CS8767
         public bool TryGetValue(PrimitiveType key, [MaybeNullWhen(false)] out StackItem value)
+#pragma warning restore CS8767
         {
             if (key.Size > MaxKeySize)
                 throw new ArgumentException($"MaxKeySize exceed: {key.Size}");

--- a/src/Neo.VM/Types/Map.cs
+++ b/src/Neo.VM/Types/Map.cs
@@ -27,7 +27,7 @@ namespace Neo.VM.Types
         /// </summary>
         public const int MaxKeySize = 64;
 
-        private readonly OrderedDictionary<PrimitiveType, StackItem> dictionary = new();
+        private readonly OrderedDictionary<PrimitiveType, StackItem> dictionary = new OrderedDictionary<PrimitiveType, StackItem>();
 
         /// <summary>
         /// Gets or sets the element that has the specified key in the map.
@@ -116,7 +116,7 @@ namespace Neo.VM.Types
         internal override StackItem DeepCopy(Dictionary<StackItem, StackItem> refMap, bool asImmutable)
         {
             if (refMap.TryGetValue(this, out StackItem? mappedItem)) return mappedItem;
-            Map result = new(ReferenceCounter);
+            Map result = new Map(ReferenceCounter);
             refMap.Add(this, result);
             foreach (var (k, v) in dictionary)
                 result[k] = v.DeepCopy(refMap, asImmutable);

--- a/src/Neo.VM/Types/StackItem.cs
+++ b/src/Neo.VM/Types/StackItem.cs
@@ -33,7 +33,7 @@ namespace Neo.VM.Types
         {
             get
             {
-                tls_true ??= new(true);
+                tls_true ??= new Boolean(true);
                 return tls_true;
             }
         }
@@ -48,7 +48,7 @@ namespace Neo.VM.Types
         {
             get
             {
-                tls_false ??= new(false);
+                tls_false ??= new Boolean(false);
                 return tls_false;
             }
         }
@@ -63,7 +63,7 @@ namespace Neo.VM.Types
         {
             get
             {
-                tls_null ??= new();
+                tls_null ??= new Null();
                 return tls_null;
             }
         }
@@ -100,7 +100,7 @@ namespace Neo.VM.Types
         /// <returns>The copied object.</returns>
         public StackItem DeepCopy(bool asImmutable = false)
         {
-            return DeepCopy(new(ReferenceEqualityComparer.Instance), asImmutable);
+            return DeepCopy(new Dictionary<StackItem, StackItem>(ReferenceEqualityComparer.Instance), asImmutable);
         }
 
         internal virtual StackItem DeepCopy(Dictionary<StackItem, StackItem> refMap, bool asImmutable)

--- a/src/Neo.VM/Types/Struct.cs
+++ b/src/Neo.VM/Types/Struct.cs
@@ -89,7 +89,7 @@ namespace Neo.VM.Types
 
         internal override bool Equals(StackItem? other, ExecutionEngineLimits limits)
         {
-            if (!(other is Struct s)) return  false;
+            if (!(other is Struct s)) return false;
             Stack<StackItem> stack1 = new Stack<StackItem>();
             Stack<StackItem> stack2 = new Stack<StackItem>();
             stack1.Push(this);

--- a/src/Neo.VM/Types/Struct.cs
+++ b/src/Neo.VM/Types/Struct.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -89,45 +89,53 @@ namespace Neo.VM.Types
 
         internal override bool Equals(StackItem? other, ExecutionEngineLimits limits)
         {
-            if (other is not Struct s) return false;
-            Stack<StackItem> stack1 = new();
-            Stack<StackItem> stack2 = new();
-            stack1.Push(this);
-            stack2.Push(s);
-            uint count = limits.MaxStackSize;
-            uint maxComparableSize = limits.MaxComparableSize;
-            while (stack1.Count > 0)
+            if (other is Struct s)
             {
-                if (count-- == 0)
-                    throw new InvalidOperationException("Too many struct items to compare.");
-                StackItem a = stack1.Pop();
-                StackItem b = stack2.Pop();
-                if (a is ByteString byteString)
+                Stack<StackItem> stack1 = new Stack<StackItem>();
+                Stack<StackItem> stack2 = new Stack<StackItem>();
+                stack1.Push(this);
+                stack2.Push(s);
+                uint count = limits.MaxStackSize;
+                uint maxComparableSize = limits.MaxComparableSize;
+                while (stack1.Count > 0)
                 {
-                    if (!byteString.Equals(b, ref maxComparableSize)) return false;
-                }
-                else
-                {
-                    if (maxComparableSize == 0)
-                        throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
-                    maxComparableSize -= 1;
-                    if (a is Struct sa)
+                    if (count-- == 0)
+                        throw new InvalidOperationException("Too many struct items to compare.");
+                    StackItem a = stack1.Pop();
+                    StackItem b = stack2.Pop();
+                    if (a is ByteString byteString)
                     {
-                        if (ReferenceEquals(a, b)) continue;
-                        if (b is not Struct sb) return false;
-                        if (sa.Count != sb.Count) return false;
-                        foreach (StackItem item in sa)
-                            stack1.Push(item);
-                        foreach (StackItem item in sb)
-                            stack2.Push(item);
+                        if (!byteString.Equals(b, ref maxComparableSize)) return false;
                     }
                     else
                     {
-                        if (!a.Equals(b)) return false;
+                        if (maxComparableSize == 0)
+                            throw new InvalidOperationException("The operand exceeds the maximum comparable size.");
+                        maxComparableSize -= 1;
+                        if (a is Struct sa)
+                        {
+                            if (ReferenceEquals(a, b)) continue;
+                            if (b is Struct sb)
+                            {
+                                if (sa.Count != sb.Count) return false;
+                                foreach (StackItem item in sa)
+                                    stack1.Push(item);
+                                foreach (StackItem item in sb)
+                                    stack2.Push(item);
+                            }
+                            else
+                                return false;
+                        }
+                        else
+                        {
+                            if (!a.Equals(b)) return false;
+                        }
                     }
                 }
+                return true;
             }
-            return true;
+
+            return false;
         }
     }
 }

--- a/src/Neo.VM/Types/Struct.cs
+++ b/src/Neo.VM/Types/Struct.cs
@@ -47,8 +47,8 @@ namespace Neo.VM.Types
         public Struct Clone(ExecutionEngineLimits limits)
         {
             int count = (int)(limits.MaxStackSize - 1);
-            Struct result = new(ReferenceCounter);
-            Queue<Struct> queue = new();
+            Struct result = new Struct(ReferenceCounter);
+            Queue<Struct> queue = new Queue<Struct>();
             queue.Enqueue(result);
             queue.Enqueue(this);
             while (queue.Count > 0)
@@ -61,7 +61,7 @@ namespace Neo.VM.Types
                     if (count < 0) throw new InvalidOperationException("Beyond clone limits!");
                     if (item is Struct sb)
                     {
-                        Struct sa = new(ReferenceCounter);
+                        Struct sa = new Struct(ReferenceCounter);
                         a.Add(sa);
                         queue.Enqueue(sa);
                         queue.Enqueue(sb);

--- a/src/Neo.VM/Utility.cs
+++ b/src/Neo.VM/Utility.cs
@@ -1,15 +1,16 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
 using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Neo.VM
@@ -58,5 +59,31 @@ namespace Neo.VM
 
             return z;
         }
+
+#if !NET5_0_OR_GREATER
+        static int GetBitLength(this BigInteger i)
+        {
+            byte[] b = i.ToByteArray();
+            return (b.Length - 1) * 8 + BitLen(i.Sign > 0 ? b[b.Length - 1] : 255 - b[b.Length - 1]);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static int BitLen(int w)
+        {
+            return (w < 1 << 15 ? (w < 1 << 7
+                ? (w < 1 << 3 ? (w < 1 << 1
+                ? (w < 1 << 0 ? (w < 0 ? 32 : 0) : 1)
+                : (w < 1 << 2 ? 2 : 3)) : (w < 1 << 5
+                ? (w < 1 << 4 ? 4 : 5)
+                : (w < 1 << 6 ? 6 : 7)))
+                : (w < 1 << 11
+                ? (w < 1 << 9 ? (w < 1 << 8 ? 8 : 9) : (w < 1 << 10 ? 10 : 11))
+                : (w < 1 << 13 ? (w < 1 << 12 ? 12 : 13) : (w < 1 << 14 ? 14 : 15)))) : (w < 1 << 23 ? (w < 1 << 19
+                ? (w < 1 << 17 ? (w < 1 << 16 ? 16 : 17) : (w < 1 << 18 ? 18 : 19))
+                : (w < 1 << 21 ? (w < 1 << 20 ? 20 : 21) : (w < 1 << 22 ? 22 : 23))) : (w < 1 << 27
+                ? (w < 1 << 25 ? (w < 1 << 24 ? 24 : 25) : (w < 1 << 26 ? 26 : 27))
+                : (w < 1 << 29 ? (w < 1 << 28 ? 28 : 29) : (w < 1 << 30 ? 30 : 31)))));
+        }
+#endif
     }
 }

--- a/src/Neo.VM/VMUnhandledException.cs
+++ b/src/Neo.VM/VMUnhandledException.cs
@@ -37,7 +37,7 @@ namespace Neo.VM
 
         private static string GetExceptionMessage(StackItem e)
         {
-            StringBuilder sb = new("An unhandled exception was thrown.");
+            StringBuilder sb = new StringBuilder("An unhandled exception was thrown.");
             ByteString? s = e as ByteString;
             if (s is null && e is Array array && array.Count > 0)
                 s = array[0] as ByteString;


### PR DESCRIPTION
In order to support Unity (https://github.com/neo-project/neo/issues/2824), we need a version of RPC Client that supports .NET Standard 2.1. Since the Neo domain model depends on Neo.VM, we will also need a .NET Standard 2.1 compatible version of Neo.VM. This PR updates NeoVM to target .NET Standard 2.1, .NET 5 and .NET 6

cc @erikzhang @shargon @roman-khimov @igormcoelho for review
cc @gsmachado @somniumwave @logikonline for input

Two of the changes were somewhat significant.
* C# 8 doesn't support `record` types, so `ExecutionEngineLimits` was re-written as a class. In order to retain `record` semantics, `IEquatable<ExecutionEngineLimits>` was manually implemented. C# 8 also doesn't support `init` property setters, so a `#if NET5_0_OR_GREATER` preprocessor directive is used to declare `ExecutionEngineLimits` properties as having normal `set` methods instead of `init` on .NET Standard 2.1. On .NET 5/6, `init` set methods continue to be used.
* C# 8 doesn't support relational pattern in switch expressions, as used in `ScriptBuilder.EmitPush` 
``` cs
            return bytesWritten switch
            {
                1 => Emit(OpCode.PUSHINT8, PadRight(buffer, bytesWritten, 1, value.Sign < 0)),
                2 => Emit(OpCode.PUSHINT16, PadRight(buffer, bytesWritten, 2, value.Sign < 0)),
                <= 4 => Emit(OpCode.PUSHINT32, PadRight(buffer, bytesWritten, 4, value.Sign < 0)),
                <= 8 => Emit(OpCode.PUSHINT64, PadRight(buffer, bytesWritten, 8, value.Sign < 0)),
                <= 16 => Emit(OpCode.PUSHINT128, PadRight(buffer, bytesWritten, 16, value.Sign < 0)),
                _ => Emit(OpCode.PUSHINT256, PadRight(buffer, bytesWritten, 32, value.Sign < 0)),
            };
```
this was replaced with code similar to what the C# compiler generates (verified via ILSpy)
```cs
            return bytesWritten <= 8
                ? bytesWritten > 4
                    ? Emit(OpCode.PUSHINT64, PadRight(buffer, bytesWritten, 8, value.Sign < 0))
                    : bytesWritten switch
                    {
                        1 => Emit(OpCode.PUSHINT8, PadRight(buffer, bytesWritten, 1, value.Sign < 0)),
                        2 => Emit(OpCode.PUSHINT16, PadRight(buffer, bytesWritten, 2, value.Sign < 0)),
                        _ => Emit(OpCode.PUSHINT32, PadRight(buffer, bytesWritten, 4, value.Sign < 0)),
                    }
                : bytesWritten > 16
                    ? Emit(OpCode.PUSHINT256, PadRight(buffer, bytesWritten, 32, value.Sign < 0))
                    : Emit(OpCode.PUSHINT128, PadRight(buffer, bytesWritten, 16, value.Sign < 0));
```
If folks think this is too complicated, we can replace it with a series of if statements.

Remaining changes are fairly minor:
* Explicitly specify object type instead of using target-type object creation (`SomeType value = new()`) for C# 8 compat
* Invert if statements using `is not` patterns for C# 8 compat
* Replace use of or pattern in `ReferenceCounter.NeedTrack` with two separate if statements
* Implement `BitOperations.RotateLeft`, `ReferenceEqualityComparer` and `BigInteger.GetBitLength` on .NET Standard 2.1 (.NET 5 and 6 use the BCL provided versions)
* Use `new byte[]` instead of `GC.AllocateUninitializedArray` on .NET Standard 2.1 (.NET 5 and 6 continue to use `GC.AllocateUninitializedArray`)
* Use non generic version of Enum.IsDefined for .NET standard 2.1 compat
* Suppress warning of value parameter nullability mismatch in `IDictionary<K,V>.TryGetValue` implementations
