### PR TITLE
Support .NET Standard 2.1(Take two)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-        - ${{ env.DOTNET_VERSION }}
-        - 3.1.x
+          ${{ env.DOTNET_VERSION }}
+          3.1.x
     - name: Check format
       run: |
         dotnet format --verify-no-changes --verbosity diagnostic

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
           ${{ env.DOTNET_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: "./coverage/lcov.net6.0.info"
 
   PublishGithub:
     # Because sometimes this action is not working as expected we will disable it until determine that it's more stable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        dotnet-version: |
+        - ${{ env.DOTNET_VERSION }}
+        - 3.1.x
     - name: Check format
       run: |
         dotnet format --verify-no-changes --verbosity diagnostic

--- a/src/Neo.VM/Collections/OrderedDictionary.cs
+++ b/src/Neo.VM/Collections/OrderedDictionary.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -76,7 +76,10 @@ namespace Neo.VM.Collections
             return collection.Remove(key);
         }
 
+// supress warning of value parameter nullability mismatch
+#pragma warning disable CS8767
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767
         {
             if (collection.TryGetValue(key, out var entry))
             {

--- a/src/Neo.VM/Collections/OrderedDictionary.cs
+++ b/src/Neo.VM/Collections/OrderedDictionary.cs
@@ -76,7 +76,7 @@ namespace Neo.VM.Collections
             return collection.Remove(key);
         }
 
-// supress warning of value parameter nullability mismatch
+        // supress warning of value parameter nullability mismatch
 #pragma warning disable CS8767
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
 #pragma warning restore CS8767

--- a/src/Neo.VM/Cryptography/BitOperations.cs
+++ b/src/Neo.VM/Cryptography/BitOperations.cs
@@ -1,0 +1,27 @@
+// Copyright (C) 2016-2022 The Neo Project.
+//
+// The neo-vm is free software distributed under the MIT software license,
+// see the accompanying file LICENSE in the main directory of the
+// project or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Runtime.CompilerServices;
+
+namespace Neo.VM.Cryptography
+{
+#if !NET5_0_OR_GREATER
+    static class BitOperations
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint RotateLeft(uint value, int offset)
+            => (value << offset) | (value >> (32 - offset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong RotateLeft(ulong value, int offset)
+            => (value << offset) | (value >> (64 - offset));
+    }
+#endif
+}

--- a/src/Neo.VM/Instruction.cs
+++ b/src/Neo.VM/Instruction.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -191,7 +191,7 @@ namespace Neo.VM
         private Instruction(OpCode opcode)
         {
             this.OpCode = opcode;
-            if (!Enum.IsDefined(opcode)) throw new BadScriptException();
+            if (!Enum.IsDefined(typeof(OpCode), opcode)) throw new BadScriptException();
         }
 
         internal Instruction(ReadOnlyMemory<byte> script, int ip) : this((OpCode)script.Span[ip++])

--- a/src/Neo.VM/IsExternalInit.cs
+++ b/src/Neo.VM/IsExternalInit.cs
@@ -1,0 +1,17 @@
+#if !NET5_0_OR_GREATER
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/src/Neo.VM/Neo.VM.csproj
+++ b/src/Neo.VM/Neo.VM.csproj
@@ -5,7 +5,8 @@
     <Description>Neo virtual machine</Description>
     <VersionPrefix>3.4.0</VersionPrefix>
     <Authors>The Neo Project</Authors>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <PackageTags>NEO;AntShares;Blockchain;Smart Contract;VM</PackageTags>
     <PackageProjectUrl>https://github.com/neo-project/neo-vm</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Neo.VM/ReferenceEqualityComparer.cs
+++ b/src/Neo.VM/ReferenceEqualityComparer.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2016-2022 The Neo Project.
+//
+// The neo-vm is free software distributed under the MIT software license,
+// see the accompanying file LICENSE in the main directory of the
+// project or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Neo.VM
+{
+#if !NET5_0_OR_GREATER
+    // https://github.dev/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ReferenceEqualityComparer.cs
+    public sealed class ReferenceEqualityComparer : IEqualityComparer<object?>, System.Collections.IEqualityComparer
+    {
+        private ReferenceEqualityComparer() { }
+
+        public static ReferenceEqualityComparer Instance { get; } = new ReferenceEqualityComparer();
+
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(object? obj) => RuntimeHelpers.GetHashCode(obj!);
+    }
+#endif
+}

--- a/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
+++ b/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
@@ -73,11 +73,11 @@ namespace Neo.VM.StronglyConnectedComponents
 
         private void StrongConnectNonRecursive(T v)
         {
-            Stack<(T, T?, IEnumerator<T>?, int)> sstack = new();
+            Stack<(T node, T?, IEnumerator<T>?, int)> sstack = new();
             sstack.Push((v, null, null, 0));
             while (sstack.TryPop(out var state))
             {
-                v = state.Item1;
+                v = state.node;
                 var (_, w, s, n) = state;
                 switch (n)
                 {

--- a/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
+++ b/src/Neo.VM/StronglyConnectedComponents/Tarjan.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -77,7 +77,8 @@ namespace Neo.VM.StronglyConnectedComponents
             sstack.Push((v, null, null, 0));
             while (sstack.TryPop(out var state))
             {
-                (v, T? w, IEnumerator<T>? s, int n) = state;
+                v = state.Item1;
+                var (_, w, s, n) = state;
                 switch (n)
                 {
                     case 0:

--- a/src/Neo.VM/Types/Buffer.cs
+++ b/src/Neo.VM/Types/Buffer.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -77,7 +77,11 @@ namespace Neo.VM.Types
                         throw new InvalidCastException();
                     return new BigInteger(InnerBuffer.Span);
                 case StackItemType.ByteString:
+#if NET5_0_OR_GREATER
                     byte[] clone = GC.AllocateUninitializedArray<byte>(InnerBuffer.Length);
+#else
+                    byte[] clone = new byte[InnerBuffer.Length];
+#endif
                     InnerBuffer.CopyTo(clone);
                     return clone;
                 default:

--- a/src/Neo.VM/Types/Map.cs
+++ b/src/Neo.VM/Types/Map.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -167,7 +167,10 @@ namespace Neo.VM.Types
         /// <see langword="true" /> if the map contains an element that has the specified key;
         /// otherwise, <see langword="false"/>.
         /// </returns>
+// supress warning of value parameter nullability mismatch
+#pragma warning disable CS8767
         public bool TryGetValue(PrimitiveType key, [MaybeNullWhen(false)] out StackItem value)
+#pragma warning restore CS8767
         {
             if (key.Size > MaxKeySize)
                 throw new ArgumentException($"MaxKeySize exceed: {key.Size}");

--- a/src/Neo.VM/Utility.cs
+++ b/src/Neo.VM/Utility.cs
@@ -1,15 +1,16 @@
 // Copyright (C) 2016-2022 The Neo Project.
-// 
-// The neo-vm is free software distributed under the MIT software license, 
+//
+// The neo-vm is free software distributed under the MIT software license,
 // see the accompanying file LICENSE in the main directory of the
-// project or http://www.opensource.org/licenses/mit-license.php 
+// project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
 using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Neo.VM
@@ -58,5 +59,31 @@ namespace Neo.VM
 
             return z;
         }
+
+#if !NET5_0_OR_GREATER
+        static int GetBitLength(this BigInteger i)
+        {
+            byte[] b = i.ToByteArray();
+            return (b.Length - 1) * 8 + BitLen(i.Sign > 0 ? b[b.Length - 1] : 255 - b[b.Length - 1]);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static int BitLen(int w)
+        {
+            return (w < 1 << 15 ? (w < 1 << 7
+                ? (w < 1 << 3 ? (w < 1 << 1
+                ? (w < 1 << 0 ? (w < 0 ? 32 : 0) : 1)
+                : (w < 1 << 2 ? 2 : 3)) : (w < 1 << 5
+                ? (w < 1 << 4 ? 4 : 5)
+                : (w < 1 << 6 ? 6 : 7)))
+                : (w < 1 << 11
+                ? (w < 1 << 9 ? (w < 1 << 8 ? 8 : 9) : (w < 1 << 10 ? 10 : 11))
+                : (w < 1 << 13 ? (w < 1 << 12 ? 12 : 13) : (w < 1 << 14 ? 14 : 15)))) : (w < 1 << 23 ? (w < 1 << 19
+                ? (w < 1 << 17 ? (w < 1 << 16 ? 16 : 17) : (w < 1 << 18 ? 18 : 19))
+                : (w < 1 << 21 ? (w < 1 << 20 ? 20 : 21) : (w < 1 << 22 ? 22 : 23))) : (w < 1 << 27
+                ? (w < 1 << 25 ? (w < 1 << 24 ? 24 : 25) : (w < 1 << 26 ? 26 : 27))
+                : (w < 1 << 29 ? (w < 1 << 28 ? 28 : 29) : (w < 1 << 30 ? 30 : 31)))));
+        }
+#endif
     }
 }

--- a/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
+++ b/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <RootNamespace>Neo.Test</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>

--- a/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
+++ b/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <RootNamespace>Neo.Test</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>

--- a/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
+++ b/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Neo.Test</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This is an alternative version of #498. That PR uses C# 8.0. This PR uses C# 9.0. Technically, C# 9 is only supported on .NET 5 and later, but Microsoft itself uses approaches from this PR to target older frameworks from C# 9.0. ([Example](https://github.com/dotnet/orleans)).

cc @erikzhang @shargon @igormcoelho 

* in order to support init only properties, Neo.VM needs a local internal copy of `IsExternalInit`. This is a marker class with no code, and is only used by the compiler for tracking metadata.
* .NET 5 is no longer supported, so this PR only targets .NET Standard 2.1 and 6.0

Other changes in this PR that match changes made in #498:

* Implement `BitOperations.RotateLeft`, `ReferenceEqualityComparer` and `BigInteger.GetBitLength` on .NET Standard 2.1 (.NET 6 uses the BCL provided versions)
* Use non generic version of Enum.IsDefined for .NET standard 2.1 compat
* Use `new byte[]` instead of `GC.AllocateUninitializedArray` on .NET Standard 2.1 (.NET 6 continues to use `GC.AllocateUninitializedArray`)
* Suppress warning of value parameter nullability mismatch in `IDictionary<K,V>.TryGetValue` implementations
* `Tarjan.StrongConnectNonRecursive` uses mixed declarations and assignment in deconstruction, which is a C# 10 feature. As this is the only post C# 9.0 feature used across the entire assembly, I changed the code to separate assignment and declarations into separate statements. So ``` (v, T? w, IEnumerator<T>? s, int n) = state;``` became ```v = state.node; var (_, w, s, n) = state; ```

Note, like #498, this PR should not be merged until after Neo 3.5 has shipped.