### PR TITLE
Add buffer limit

### DIFF
--- a/src/Neo.VM/ExecutionEngine.cs
+++ b/src/Neo.VM/ExecutionEngine.cs
@@ -1696,7 +1696,20 @@ namespace Neo.VM
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Push(StackItem item)
         {
+            if (item is Buffer buff)
+            {
+                MemorySize += buff.Size;
+                if (MemorySize > Limits.MaxMemorySize)
+                {
+                    throw new InvalidOperationException($"MaxMemorySize exceed: {MemorySize}");
+                }
+            }
             CurrentContext!.EvaluationStack.Push(item);
         }
+
+        /// <summary>
+        /// Used memory size
+        /// </summary>
+        public long MemorySize { get; private set; }
     }
 }

--- a/src/Neo.VM/ExecutionEngineLimits.cs
+++ b/src/Neo.VM/ExecutionEngineLimits.cs
@@ -39,6 +39,11 @@ namespace Neo.VM
         public uint MaxItemSize { get; init; } = 1024 * 1024;
 
         /// <summary>
+        /// The maximum size of used memory in the VM.
+        /// </summary>
+        public uint MaxMemorySize { get; init; } = 100 * 1024 * 1024;
+
+        /// <summary>
         /// The largest comparable size. If a <see cref="Types.ByteString"/> or <see cref="Types.Struct"/> exceeds this size, comparison operations on it cannot be performed in the VM.
         /// </summary>
         public uint MaxComparableSize { get; init; } = 65536;


### PR DESCRIPTION
The `Buffer` type in VM could occupy up to 2GB memory easily, which was abused by malicious users to slow down public nodes.
This PR try to limit max used size of `Buffer` up to 100MB in a single execution.