### PR TITLE
Enhance the limits

### DIFF
--- a/src/Neo.VM/ExecutionEngineLimits.cs
+++ b/src/Neo.VM/ExecutionEngineLimits.cs
@@ -36,7 +36,7 @@ namespace Neo.VM
         /// <summary>
         /// The maximum size of an item in the VM.
         /// </summary>
-        public uint MaxItemSize { get; init; } = ushort.MaxValue;
+        public uint MaxItemSize { get; init; } = ushort.MaxValue * 2;
 
         /// <summary>
         /// The largest comparable size. If a <see cref="Types.ByteString"/> or <see cref="Types.Struct"/> exceeds this size, comparison operations on it cannot be performed in the VM.

--- a/src/Neo.VM/ExecutionEngineLimits.cs
+++ b/src/Neo.VM/ExecutionEngineLimits.cs
@@ -41,7 +41,7 @@ namespace Neo.VM
         /// <summary>
         /// The largest comparable size. If a <see cref="Types.ByteString"/> or <see cref="Types.Struct"/> exceeds this size, comparison operations on it cannot be performed in the VM.
         /// </summary>
-        public uint MaxComparableSize { get; init; } = ushort.MaxValue;
+        public uint MaxComparableSize { get; init; } = 65536;
 
         /// <summary>
         /// The maximum number of frames in the invocation stack of the VM.

--- a/src/Neo.VM/ExecutionEngineLimits.cs
+++ b/src/Neo.VM/ExecutionEngineLimits.cs
@@ -36,12 +36,12 @@ namespace Neo.VM
         /// <summary>
         /// The maximum size of an item in the VM.
         /// </summary>
-        public uint MaxItemSize { get; init; } = 1024 * 1024;
+        public uint MaxItemSize { get; init; } = ushort.MaxValue;
 
         /// <summary>
         /// The largest comparable size. If a <see cref="Types.ByteString"/> or <see cref="Types.Struct"/> exceeds this size, comparison operations on it cannot be performed in the VM.
         /// </summary>
-        public uint MaxComparableSize { get; init; } = 65536;
+        public uint MaxComparableSize { get; init; } = ushort.MaxValue;
 
         /// <summary>
         /// The maximum number of frames in the invocation stack of the VM.


### PR DESCRIPTION
As conversed with @roman-khimov 

Alternative to fix https://github.com/neo-project/neo-vm/pull/512

Max transaction script size is [64Kb](https://github.com/neo-project/neo/blob/f5e257c11c514e47cdc1da6116e475a7324ba1ac/src/Neo/Network/P2P/Payloads/Transaction.cs#L240), has no sense to have a bigger item, the longest one should be a nef file, and it should be limited to the transaction script size ([now is not](https://github.com/neo-project/neo/blob/f5e257c11c514e47cdc1da6116e475a7324ba1ac/src/Neo/SmartContract/Native/ContractManagement.cs#L218C91-L218C98))