### PR TITLE
Ensure coveralls receives lcov report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
         dotnet format --verify-no-changes --verbosity diagnostic
     - name: Test
       run: |
+        find tests -name '*.csproj' -print0 | xargs -0 -n1 -I{} dotnet add "{}" package coverlet.msbuild
         dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${GITHUB_WORKSPACE}/coverage/lcov
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
+++ b/tests/Neo.VM.Tests/Neo.VM.Tests.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.0.1" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add coverlet.msbuild as a test dependency so coverage instrumentation is always available
- simplify CI workflow to run dotnet test with coverage output directly into coverage/lcov.info

## Testing
- dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=/home/neo/neo-feature/neo-vm/coverage/lcov