### PR TITLE
perf: add slot handling optimizations

### DIFF
--- a/benchmarks/Neo.VM.Benchmarks/Benchmarks_Optimizations.cs
+++ b/benchmarks/Neo.VM.Benchmarks/Benchmarks_Optimizations.cs
@@ -1,0 +1,147 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Benchmarks_Optimizations.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using BenchmarkDotNet.Attributes;
+using Neo.VM.Benchmarks.Builders;
+using Neo.VM.Types;
+using BuilderInstruction = Neo.VM.Benchmarks.Builders.Instruction;
+using SysArray = System.Array;
+
+namespace Neo.VM.Benchmarks.OpCodes;
+
+[MemoryDiagnoser]
+[InvocationCount(1)]
+[IterationCount(10)]
+[WarmupCount(3)]
+public class Benchmarks_Optimizations
+{
+    private const int LoopIterations = 100000;
+    private const int SmallArraySize = 8;
+    private const int MediumArraySize = 32;
+    private const int LargeArraySize = 128;
+
+    private byte[] _newArraySmallScript = SysArray.Empty<byte>();
+    private byte[] _newArrayMediumScript = SysArray.Empty<byte>();
+    private byte[] _newArrayLargeScript = SysArray.Empty<byte>();
+    private byte[] _newStructScript = SysArray.Empty<byte>();
+    private byte[] _initSlotScript = SysArray.Empty<byte>();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _newArraySmallScript = BuildLoop(OpCode.NEWARRAY, SmallArraySize);
+        _newArrayMediumScript = BuildLoop(OpCode.NEWARRAY, MediumArraySize);
+        _newArrayLargeScript = BuildLoop(OpCode.NEWARRAY, LargeArraySize);
+        _newStructScript = BuildLoop(OpCode.NEWSTRUCT, SmallArraySize);
+        _initSlotScript = BuildInitSlotScript(SmallArraySize);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = LoopIterations)]
+    public void NewArray_Small()
+    {
+        RunScript(_newArraySmallScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void NewArray_Medium()
+    {
+        RunScript(_newArrayMediumScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void NewArray_Large()
+    {
+        RunScript(_newArrayLargeScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void NewStruct()
+    {
+        RunScript(_newStructScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void InitSlot()
+    {
+        RunScript(_initSlotScript);
+    }
+
+    // Memory allocation benchmarks
+    [Benchmark]
+    public void CreateManyArrays_UsingPool()
+    {
+        using var engine = new SimpleBenchmarkEngine();
+        for (int i = 0; i < 10000; i++)
+        {
+            var arr = new Neo.VM.Types.Array(engine.ReferenceCounter, StackItem.Null, SmallArraySize, skipReferenceCounting: false);
+        }
+    }
+
+    private static void RunScript(byte[] script)
+    {
+        using var engine = new SimpleBenchmarkEngine();
+        engine.LoadScript(script);
+        while (engine.State != VMState.HALT && engine.State != VMState.FAULT)
+        {
+            engine.ExecuteNext();
+        }
+    }
+
+    private static byte[] BuildLoop(OpCode opCode, int size)
+    {
+        var builder = new InstructionBuilder();
+        builder.Push(LoopIterations);
+        builder.AddInstruction(OpCode.STLOC0);
+
+        var loopStart = new JumpTarget
+        {
+            _instruction = builder.AddInstruction(OpCode.NOP)
+        };
+
+        builder.Push(size);
+        builder.AddInstruction(opCode);
+        builder.AddInstruction(OpCode.DROP);
+
+        builder.AddInstruction(OpCode.LDLOC0);
+        builder.AddInstruction(OpCode.DEC);
+        builder.AddInstruction(OpCode.STLOC0);
+        builder.AddInstruction(OpCode.LDLOC0);
+        builder.Jump(OpCode.JMPIF, loopStart);
+        builder.Ret();
+        return builder.ToArray();
+    }
+
+    private static byte[] BuildInitSlotScript(int slotSize)
+    {
+        var builder = new InstructionBuilder();
+        // Push some items on stack
+        for (int i = 0; i < slotSize; i++)
+        {
+            builder.Push(i);
+        }
+        // InitSlot with arguments = slotSize, locals = 0
+        builder.AddInstruction(new BuilderInstruction
+        {
+            _opCode = OpCode.INITSLOT,
+            _operand = [0, (byte)slotSize]
+        });
+        builder.Ret();
+        return builder.ToArray();
+    }
+
+    private sealed class SimpleBenchmarkEngine : ExecutionEngine
+    {
+        public SimpleBenchmarkEngine()
+            : base(null, new ReferenceCounter(), ExecutionEngineLimits.Default)
+        {
+        }
+    }
+}

--- a/benchmarks/Neo.VM.Benchmarks/OpCodes/Benchmarks_NewItems.cs
+++ b/benchmarks/Neo.VM.Benchmarks/OpCodes/Benchmarks_NewItems.cs
@@ -1,0 +1,220 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Benchmarks_NewItems.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using BenchmarkDotNet.Attributes;
+using Neo.VM.Benchmarks.Builders;
+using Neo.VM.Types;
+using BuilderInstruction = Neo.VM.Benchmarks.Builders.Instruction;
+using SysArray = System.Array;
+
+namespace Neo.VM.Benchmarks.OpCodes;
+
+[MemoryDiagnoser]
+[InvocationCount(1)]
+[IterationCount(10)]
+[WarmupCount(3)]
+public class Benchmarks_NewItems
+{
+    private const int LoopIterations = 1048576;
+    private const int ArraySize = 16;
+    private const int BufferSize = 32;
+
+    private byte[] _baselineScript = SysArray.Empty<byte>();
+    private byte[] _newArrayScript = SysArray.Empty<byte>();
+    private byte[] _newStructScript = SysArray.Empty<byte>();
+    private byte[] _newArrayTScript = SysArray.Empty<byte>();
+    private byte[] _newBufferScript = SysArray.Empty<byte>();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _baselineScript = BuildLoop();
+        _newArrayScript = BuildLoop(OpCode.NEWARRAY, ArraySize);
+        _newStructScript = BuildLoop(OpCode.NEWSTRUCT, ArraySize);
+        _newArrayTScript = BuildLoop(OpCode.NEWARRAY_T, ArraySize, StackItemType.Integer);
+        _newBufferScript = BuildLoop(OpCode.NEWBUFFER, BufferSize);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = LoopIterations)]
+    public void Baseline()
+    {
+        RunCurrent(_baselineScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void NewArray()
+    {
+        RunCurrent(_newArrayScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void LegacyNewArray()
+    {
+        RunLegacy(_newArrayScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void NewStruct()
+    {
+        RunCurrent(_newStructScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void LegacyNewStruct()
+    {
+        RunLegacy(_newStructScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void NewArrayT()
+    {
+        RunCurrent(_newArrayTScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void LegacyNewArrayT()
+    {
+        RunLegacy(_newArrayTScript);
+    }
+
+    [Benchmark(OperationsPerInvoke = LoopIterations)]
+    public void NewBuffer()
+    {
+        RunCurrent(_newBufferScript);
+    }
+
+    private static void RunCurrent(byte[] script)
+    {
+        using var engine = new SimpleBenchmarkEngine();
+        RunWithEngine(script, engine);
+    }
+
+    private static void RunLegacy(byte[] script)
+    {
+        using var engine = new SimpleBenchmarkEngine(new LegacyJumpTable());
+        RunWithEngine(script, engine);
+    }
+
+    private static void RunWithEngine(byte[] script, SimpleBenchmarkEngine engine)
+    {
+        engine.LoadScript(script);
+        engine.ExecuteBenchmark();
+    }
+
+    private static byte[] BuildLoop(OpCode? createOp = null, int size = 0, StackItemType arrayType = StackItemType.Any)
+    {
+        var builder = new InstructionBuilder();
+        builder.AddInstruction(new BuilderInstruction
+        {
+            _opCode = OpCode.INITSLOT,
+            _operand = [1, 0]
+        });
+        builder.Push(LoopIterations);
+        builder.AddInstruction(OpCode.STLOC0);
+
+        var loopStart = new JumpTarget
+        {
+            _instruction = builder.AddInstruction(OpCode.NOP)
+        };
+
+        if (createOp.HasValue)
+        {
+            builder.Push(size);
+            if (createOp.Value == OpCode.NEWARRAY_T)
+            {
+                builder.AddInstruction(new BuilderInstruction
+                {
+                    _opCode = OpCode.NEWARRAY_T,
+                    _operand = [(byte)arrayType]
+                });
+            }
+            else
+            {
+                builder.AddInstruction(createOp.Value);
+            }
+            builder.AddInstruction(OpCode.DROP);
+        }
+
+        builder.AddInstruction(OpCode.LDLOC0);
+        builder.AddInstruction(OpCode.DEC);
+        builder.AddInstruction(OpCode.STLOC0);
+        builder.AddInstruction(OpCode.LDLOC0);
+        builder.Jump(OpCode.JMPIF, loopStart);
+        builder.Ret();
+        return builder.ToArray();
+    }
+
+    private sealed class SimpleBenchmarkEngine : ExecutionEngine
+    {
+        public SimpleBenchmarkEngine(JumpTable? jumpTable = null)
+            : base(jumpTable, new ReferenceCounter(), ExecutionEngineLimits.Default)
+        {
+        }
+
+        public void ExecuteBenchmark()
+        {
+            while (State != VMState.HALT && State != VMState.FAULT)
+            {
+                ExecuteNext();
+            }
+        }
+    }
+
+    private sealed class LegacyJumpTable : JumpTable
+    {
+        public override void NewArray(ExecutionEngine engine, Neo.VM.Instruction instruction)
+        {
+            var n = (int)engine.Pop().GetInteger();
+            if (n < 0 || n > engine.Limits.MaxStackSize)
+                throw new InvalidOperationException($"The array size is out of valid range, {n}/[0, {engine.Limits.MaxStackSize}].");
+            var nullArray = new StackItem[n];
+            System.Array.Fill(nullArray, StackItem.Null);
+            engine.Push(new Neo.VM.Types.Array(engine.ReferenceCounter, nullArray));
+        }
+
+        public override void NewArray_T(ExecutionEngine engine, Neo.VM.Instruction instruction)
+        {
+            var n = (int)engine.Pop().GetInteger();
+            if (n < 0 || n > engine.Limits.MaxStackSize)
+                throw new InvalidOperationException($"The array size is out of valid range, {n}/[0, {engine.Limits.MaxStackSize}].");
+
+            var type = (StackItemType)instruction.TokenU8;
+#if NET5_0_OR_GREATER
+            if (!Enum.IsDefined(type))
+#else
+            if (!Enum.IsDefined(typeof(StackItemType), type))
+#endif
+                throw new InvalidOperationException($"Invalid type for {instruction.OpCode}: {instruction.TokenU8}");
+
+            var item = instruction.TokenU8 switch
+            {
+                (byte)StackItemType.Boolean => StackItem.False,
+                (byte)StackItemType.Integer => Integer.Zero,
+                (byte)StackItemType.ByteString => ByteString.Empty,
+                _ => StackItem.Null
+            };
+            var itemArray = new StackItem[n];
+            System.Array.Fill(itemArray, item);
+            engine.Push(new Neo.VM.Types.Array(engine.ReferenceCounter, itemArray));
+        }
+
+        public override void NewStruct(ExecutionEngine engine, Neo.VM.Instruction instruction)
+        {
+            var n = (int)engine.Pop().GetInteger();
+            if (n < 0 || n > engine.Limits.MaxStackSize)
+                throw new InvalidOperationException($"The struct size is out of valid range, {n}/[0, {engine.Limits.MaxStackSize}].");
+
+            var nullArray = new StackItem[n];
+            System.Array.Fill(nullArray, StackItem.Null);
+            engine.Push(new Struct(engine.ReferenceCounter, nullArray));
+        }
+    }
+}

--- a/src/Neo.VM/Slot.cs
+++ b/src/Neo.VM/Slot.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Neo.VM.Types;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Array = System.Array;
@@ -73,6 +74,36 @@ public class Slot : IReadOnlyList<StackItem>
         _items = new StackItem[count];
         Array.Fill(_items, StackItem.Null);
         referenceCounter.AddStackReference(StackItem.Null, count);
+    }
+
+    /// <summary>
+    /// Create a slot by popping items directly from the evaluation stack.
+    /// This eliminates temporary array allocation for arguments.
+    /// </summary>
+    /// <param name="count">Indicates the number of items to pop from the stack.</param>
+    /// <param name="engine">The execution engine to pop items from.</param>
+    /// <param name="referenceCounter">The reference counter to be used.</param>
+    internal Slot(int count, ExecutionEngine engine, IReferenceCounter referenceCounter)
+    {
+        if (count < 0)
+            throw new ArgumentOutOfRangeException(nameof(count));
+        if (engine == null)
+            throw new ArgumentNullException(nameof(engine));
+
+        _referenceCounter = referenceCounter;
+        _items = new StackItem[count];
+
+        // Pop items from the stack in forward order (first item is at index 0)
+        for (var i = 0; i < count; i++)
+        {
+            _items[i] = engine.Pop();
+        }
+
+        // Add stack references for all popped items
+        for (var i = 0; i < count; i++)
+        {
+            referenceCounter.AddStackReference(_items[i]);
+        }
     }
 
     internal void ClearReferences()

--- a/src/Neo.VM/Slot.cs
+++ b/src/Neo.VM/Slot.cs
@@ -87,21 +87,14 @@ public class Slot : IReadOnlyList<StackItem>
     {
         if (count < 0)
             throw new ArgumentOutOfRangeException(nameof(count));
-        if (engine == null)
-            throw new ArgumentNullException(nameof(engine));
 
         _referenceCounter = referenceCounter;
         _items = new StackItem[count];
 
-        // Pop items from the stack in forward order (first item is at index 0)
+        // Pop items and add stack references in a single iteration
         for (var i = 0; i < count; i++)
         {
             _items[i] = engine.Pop();
-        }
-
-        // Add stack references for all popped items
-        for (var i = 0; i < count; i++)
-        {
             referenceCounter.AddStackReference(_items[i]);
         }
     }


### PR DESCRIPTION
## Summary
Split from #552 - Slot handling optimizations only.

### Changes
- Add slot bounds checks and stack-pop slot constructor
- Add optimization benchmarks for slot operations
- Add NewItems benchmarks

### Independent of
- Bulk reference counting (separate PR #554)

### Test Plan
- dotnet test tests/Neo.VM.Tests