### PR TITLE
Add: detailed doc for OpCode

### DIFF
--- a/src/Neo.VM/JumpTable/JumpTable.Control.cs
+++ b/src/Neo.VM/JumpTable/JumpTable.Control.cs
@@ -635,7 +635,7 @@ partial class JumpTable
     public virtual void ExecuteTry(ExecutionEngine engine, int catchOffset, int finallyOffset)
     {
         if (catchOffset == 0 && finallyOffset == 0)
-            throw new InvalidOperationException($"catchOffset and finallyOffset can't be 0 in a TRY block");
+            throw new InvalidOperationException($"catchOffset and finallyOffset can't both be 0 in a TRY block.");
         if (engine.CurrentContext!.TryStack is null)
             engine.CurrentContext.TryStack = new Stack<ExceptionHandlingContext>();
         else if (engine.CurrentContext.TryStack.Count >= engine.Limits.MaxTryNestingDepth)

--- a/src/Neo.VM/JumpTable/JumpTable.Splice.cs
+++ b/src/Neo.VM/JumpTable/JumpTable.Splice.cs
@@ -63,6 +63,7 @@ partial class JumpTable
 
     /// <summary>
     /// Concatenates two buffers and pushes the result onto the evaluation stack.
+    /// The result is the first pushed item concatenated with the second pushed item.
     /// <see cref="OpCode.CAT"/>
     /// </summary>
     /// <param name="engine">The execution engine.</param>
@@ -82,7 +83,7 @@ partial class JumpTable
     }
 
     /// <summary>
-    /// Extracts a substring from the specified buffer and pushes it onto the evaluation stack.
+    /// Extracts a sub-buffer from the specified buffer and pushes it onto the evaluation stack.
     /// <see cref="OpCode.SUBSTR"/>
     /// </summary>
     /// <param name="engine">The execution engine.</param>


### PR DESCRIPTION
Add detailed doc for OpCode.

The doc for some opcodes is incorrect now.
For example: https://developers.neo.org/docs/n3/reference/Opcodes#8B `CAT`, `SUBSTR`.