### PR TITLE
ReferenceCounter: avoid RC underflow for cyclic references

### DIFF
--- a/src/Neo.VM/JumpTable/JumpTable.Compound.cs
+++ b/src/Neo.VM/JumpTable/JumpTable.Compound.cs
@@ -559,14 +559,15 @@ partial class JumpTable
     public virtual void ClearItems(ExecutionEngine engine, Instruction instruction)
     {
         var x = engine.Pop<CompoundType>();
+        var subItems = x.SubItems.ToList();
+        x.Clear();
         if (x.IsStackReferenced)
         {
-            foreach (var xSubItem in x.SubItems)
+            foreach (var xSubItem in subItems)
             {
                 engine.ReferenceCounter.RemoveStackReference(xSubItem);
             }
         }
-        x.Clear();
     }
 
     /// <summary>

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -63,21 +63,29 @@ public sealed class ReferenceCounter : IReferenceCounter
     /// <inheritdoc/>
     public void RemoveStackReference(StackItem item)
     {
-        // Decrease the reference count.
-        _referencesCount--;
-
         if (item is CompoundType compoundType)
         {
-            // Decrease the item's stack references.
-            compoundType.StackReferences--;
-
-            if (compoundType.StackReferences == 0)
+            if (compoundType.IsStackReferenced)
             {
-                foreach (var subItem in compoundType.SubItems)
+                // Decrease the reference count.
+                _referencesCount--;
+
+                // Decrease the item's stack references.
+                compoundType.StackReferences--;
+
+                if (compoundType.StackReferences == 0)
                 {
-                    RemoveStackReference(subItem);
+                    foreach (var subItem in compoundType.SubItems)
+                    {
+                        RemoveStackReference(subItem);
+                    }
                 }
             }
+        }
+        else
+        {
+            // Decrease the reference count.
+            _referencesCount--;
         }
     }
 }

--- a/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
+++ b/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
@@ -2010,6 +2010,181 @@
       ]
     },
     {
+      "name": "Circular reference - clear self referenced Array with primitive types",
+      "script": [
+		    "NEWARRAY0",
+        "DUP",
+        "PUSH1",
+        "APPEND",
+		    "DUP",
+		    "DUP",
+		    "APPEND",
+		    "CLEARITEMS"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 6,
+                "nextInstruction": "APPEND",
+                "evaluationStack": [
+                  {
+                    "type": "Array",
+                    "value": [ 
+                      {
+                        "type": "Integer",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Array",
+                    "value": [ 
+                      {
+                        "type": "Integer",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Array",
+                    "value": [ 
+                      {
+                        "type": "Integer",
+                        "value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "refs": 4
+          }
+        },
+        {
+          "actions": [
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 7,
+                "nextInstruction": "CLEARITEMS"
+              }
+            ],
+            "refs": 3
+          }
+        },
+        {
+          "actions": [
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 8,
+                "nextInstruction": "RET"
+              }
+            ],
+            "refs": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Circular reference - clear self referenced Map",
+      "script": [
+		    "NEWMAP",
+		    "DUP",
+		    "DUP",
+        "PUSH1",
+        "SWAP",
+        "SETITEM",
+		    "CLEARITEMS"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 5,
+                "nextInstruction": "SETITEM",
+                "evaluationStack": [
+                  {
+                    "type": "Map",
+                    "value": { }
+                  },
+                  {
+                    "type": "Integer",
+                    "value": 1
+                  },
+                  {
+                    "type": "Map",
+                    "value": { }
+                  },
+                  {
+                    "type": "Map",
+                    "value": { }
+                  }
+                ]
+              }
+            ],
+            "refs": 4
+          }
+        },
+        {
+          "actions": [
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 6,
+                "nextInstruction": "CLEARITEMS"
+              }
+            ],
+            "refs": 3
+          }
+        },
+        {
+          "actions": [
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 7,
+                "nextInstruction": "RET"
+              }
+            ],
+            "refs": 0
+          }
+        }
+      ]
+    },
+    {
       "name": "RC must not be negative due to circular reference removal",
       "script": [
        	"INITSLOT", "0x01", "0x00",

--- a/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
+++ b/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
@@ -2104,6 +2104,83 @@
       ]
     },
     {
+      "name": "Circular reference - indirect cycle (A -> B -> A); clear A",
+      "script": [
+		    "NEWARRAY0",
+        "DUP",
+        "DUP",
+        "NEWARRAY0",
+        "TUCK",
+        "APPEND",
+        "SWAP",
+        "APPEND",
+        "CLEARITEMS"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 7,
+                "nextInstruction": "APPEND",
+                "evaluationStack": [
+                  {
+                    "type": "Array",
+                    "value": [ 
+                      {
+                        "type": "Array",
+                        "value": [ ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Array",
+                    "value": [ ]
+                  },
+                  {
+                    "type": "Array",
+                    "value": [ 
+                      {
+                        "type": "Array",
+                        "value": [ ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "refs": 4
+          }
+        },
+        {
+          "actions": [
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 9,
+                "nextInstruction": "RET"
+              }
+            ],
+            "refs": 0
+          }
+        }
+      ]
+    },
+    {
       "name": "Circular reference - clear self referenced Map",
       "script": [
 		    "NEWMAP",

--- a/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
+++ b/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
@@ -1935,6 +1935,110 @@
           }
         }
       ]
+    },
+    {
+      "name": "Circular reference - clear self referenced Array",
+      "script": [
+		    "NEWARRAY0",
+		    "DUP",
+		    "DUP",
+		    "APPEND",
+		    "CLEARITEMS"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "stepInto",
+            "stepInto",
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 3,
+                "nextInstruction": "APPEND",
+                "evaluationStack": [
+                  {
+                    "type": "Array",
+                    "value": [ ]
+                  },
+                  {
+                    "type": "Array",
+                    "value": [ ]
+                  },
+                  {
+                    "type": "Array",
+                    "value": [ ]
+                  }
+                ]
+              }
+            ],
+            "refs": 3
+          }
+        },
+        {
+          "actions": [
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 4,
+                "nextInstruction": "CLEARITEMS"
+              }
+            ],
+            "refs": 2
+          }
+        },
+        {
+          "actions": [
+            "stepInto"
+          ],
+          "result": {
+            "state": "BREAK",
+            "invocationStack": [
+              {
+                "instructionPointer": 5,
+                "nextInstruction": "RET"
+              }
+            ],
+            "refs": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "RC must not be negative due to circular reference removal",
+      "script": [
+       	"INITSLOT", "0x01", "0x00",
+		    "PUSH16",
+		    "STLOC0",
+		    "NEWARRAY0",
+		    "DUP",
+		    "DUP",
+		    "APPEND",
+		    "CLEARITEMS",
+		    "LDLOC0",
+		    "DEC",
+		    "DUP",
+		    "STLOC0",
+		    "PUSH0",
+		    "JMPGT", "0xf6"
+      ],
+      "steps": [
+        {
+          "actions": [
+            "execute"
+          ],
+          "result": {
+            "state": "HALT",
+            "invocationStack": [ ],
+            "refs": 0
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Close #580. Port https://github.com/nspcc-dev/neo-go/pull/4312 and https://github.com/nspcc-dev/neo-go/pull/4313.