### PR TITLE
tests: fix format of JSON unit-tests

### DIFF
--- a/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
+++ b/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
@@ -1248,7 +1248,7 @@
         "DUP",
         "PUSH0",
         "REMOVE",
-        "DROP",
+        "DROP"
       ],
       "steps": [
         {
@@ -1939,11 +1939,11 @@
     {
       "name": "Circular reference - clear self referenced Array",
       "script": [
-		    "NEWARRAY0",
-		    "DUP",
-		    "DUP",
-		    "APPEND",
-		    "CLEARITEMS"
+        "NEWARRAY0",
+        "DUP",
+        "DUP",
+        "APPEND",
+        "CLEARITEMS"
       ],
       "steps": [
         {
@@ -2012,14 +2012,14 @@
     {
       "name": "Circular reference - clear self referenced Array with primitive types",
       "script": [
-		    "NEWARRAY0",
+        "NEWARRAY0",
         "DUP",
         "PUSH1",
         "APPEND",
-		    "DUP",
-		    "DUP",
-		    "APPEND",
-		    "CLEARITEMS"
+        "DUP",
+        "DUP",
+        "APPEND",
+        "CLEARITEMS"
       ],
       "steps": [
         {
@@ -2106,7 +2106,7 @@
     {
       "name": "Circular reference - indirect cycle (A -> B -> A); clear A",
       "script": [
-		    "NEWARRAY0",
+        "NEWARRAY0",
         "DUP",
         "DUP",
         "NEWARRAY0",
@@ -2183,13 +2183,13 @@
     {
       "name": "Circular reference - clear self referenced Map",
       "script": [
-		    "NEWMAP",
-		    "DUP",
-		    "DUP",
+        "NEWMAP",
+        "DUP",
+        "DUP",
         "PUSH1",
         "SWAP",
         "SETITEM",
-		    "CLEARITEMS"
+        "CLEARITEMS"
       ],
       "steps": [
         {
@@ -2265,19 +2265,19 @@
       "name": "RC must not be negative due to circular reference removal",
       "script": [
        	"INITSLOT", "0x01", "0x00",
-		    "PUSH16",
-		    "STLOC0",
-		    "NEWARRAY0",
-		    "DUP",
-		    "DUP",
-		    "APPEND",
-		    "CLEARITEMS",
-		    "LDLOC0",
-		    "DEC",
-		    "DUP",
-		    "STLOC0",
-		    "PUSH0",
-		    "JMPGT", "0xf6"
+       	"PUSH16",
+       	"STLOC0",
+       	"NEWARRAY0",
+       	"DUP",
+       	"DUP",
+       	"APPEND",
+       	"CLEARITEMS",
+       	"LDLOC0",
+       	"DEC",
+       	"DUP",
+       	"STLOC0",
+       	"PUSH0",
+       	"JMPGT", "0xf6"
       ],
       "steps": [
         {


### PR DESCRIPTION
Make it a valid JSON, unify indentation. Get rid of the following error while parsing ReferenceCounter.json with strict JSON parsing rules:
```
2026-06-18T09:54:40.4953246Z === NAME  TestUT
2026-06-18T09:54:40.4953415Z     json_test.go:143:
2026-06-18T09:54:40.4953792Z         	Error Trace:	/home/runner/work/neo-go/neo-go/pkg/vm/json_test.go:143
2026-06-18T09:54:40.4954373Z         	            				/home/runner/work/neo-go/neo-go/pkg/vm/json_test.go:105
2026-06-18T09:54:40.4955038Z         	            				/opt/hostedtoolcache/go/1.26.4/x64/src/path/filepath/path.go:346
2026-06-18T09:54:40.4955670Z         	            				/opt/hostedtoolcache/go/1.26.4/x64/src/path/filepath/path.go:370
2026-06-18T09:54:40.4956304Z         	            				/opt/hostedtoolcache/go/1.26.4/x64/src/path/filepath/path.go:370
2026-06-18T09:54:40.4956931Z         	            				/opt/hostedtoolcache/go/1.26.4/x64/src/path/filepath/path.go:428
2026-06-18T09:54:40.4957579Z         	            				/home/runner/work/neo-go/neo-go/pkg/vm/json_test.go:100
2026-06-18T09:54:40.4957852Z         	Error:      	Received unexpected error:
2026-06-18T09:54:40.4958370Z         	            	invalid character ']' looking for beginning of value
2026-06-18T09:54:40.4958520Z         	Test:       	TestUT
2026-06-18T09:54:40.4959097Z         	Messages:   	file: testdata/neo-vm/tests/Neo.VM.Tests/Tests/Others/ReferenceCounter.json
2026-06-18T09:54:40.4959208Z --- FAIL: TestUT (0.38s)
```