### PR TITLE
Align reference counter with neo-go

### DIFF
--- a/src/Neo.VM/IReferenceCounter.cs
+++ b/src/Neo.VM/IReferenceCounter.cs
@@ -38,10 +38,9 @@ public interface IReferenceCounter
     /// <summary>
     /// Adds a stack reference to a specified item with a count.
     ///
-    /// This method is used when an item gains a new stack reference, usually due to being pushed onto the evaluation stack.
-    /// It increments the reference count and updates the tracking structures if necessary.
-    ///
-    /// Use this method when you need to add one or more stack references to a stack item.
+    /// Always increases <see cref="Count"/>. For compound types, the item's own
+    /// reference count is increased, and children are counted only on the
+    /// transition from unreferenced to referenced (0 → 1).
     /// </summary>
     /// <param name="item">The item to add a stack reference to.</param>
     /// <param name="count">The number of references to add.</param>
@@ -50,10 +49,10 @@ public interface IReferenceCounter
     /// <summary>
     /// Removes a stack reference from a specified item.
     ///
-    /// This method is used when an item loses a stack reference, usually due to being popped off the evaluation stack.
-    /// It decrements the reference count and updates the tracking structures if necessary.
-    ///
-    /// Use this method when you need to remove one or more stack references from a stack item.
+    /// Scalar items always decrease <see cref="Count"/>. Compound types are
+    /// skipped when they are not referenced, which prevents a negative count
+    /// on cyclic structures. Children are uncounted only when the item's last
+    /// reference is dropped (1 → 0).
     /// </summary>
     /// <param name="item">The item to remove a stack reference from.</param>
     void RemoveStackReference(StackItem item);

--- a/src/Neo.VM/ReferenceCounter.cs
+++ b/src/Neo.VM/ReferenceCounter.cs
@@ -15,7 +15,11 @@ using System;
 namespace Neo.VM;
 
 /// <summary>
-/// Used for reference counting of objects in the VM.
+/// Counts VM stack items the same way neo-go does: a single integer for the
+/// total number of references, plus a per-compound <see cref="CompoundType.StackReferences"/>
+/// count. Compound children are walked only when the compound becomes
+/// referenced (0 → 1) or unreferenced (1 → 0). Unreferenced compounds are not
+/// decremented, so cyclic graphs cannot drive the counter negative.
 /// </summary>
 public sealed class ReferenceCounter : IReferenceCounter
 {
@@ -47,14 +51,13 @@ public sealed class ReferenceCounter : IReferenceCounter
     /// <inheritdoc/>
     public void AddStackReference(StackItem item, int count = 1)
     {
-        // Increment the reference count by the specified count.
         _referencesCount += count;
 
         if (item is CompoundType compoundType)
         {
-            // Increment the item's stack references by the specified count.
             compoundType.StackReferences += count;
 
+            // First reference: count children (array/struct items, map keys and values).
             if (compoundType.StackReferences == count)
             {
                 foreach (var subItem in compoundType.SubItems)
@@ -77,12 +80,11 @@ public sealed class ReferenceCounter : IReferenceCounter
     {
         if (item is CompoundType compoundType)
         {
+            // Skip compounds that are already unreferenced so cyclic graphs
+            // cannot underflow the counter and bypass MaxStackSize.
             if (compoundType.IsStackReferenced)
             {
-                // Decrease the reference count.
                 _referencesCount--;
-
-                // Decrease the item's stack references.
                 compoundType.StackReferences--;
 
                 if (compoundType.StackReferences == 0)
@@ -96,7 +98,6 @@ public sealed class ReferenceCounter : IReferenceCounter
         }
         else
         {
-            // Decrease the reference count.
             _referencesCount--;
         }
     }

--- a/src/Neo.VM/Slot.cs
+++ b/src/Neo.VM/Slot.cs
@@ -104,8 +104,10 @@ public class Slot : IReadOnlyList<StackItem>
         {
             throw new ArgumentOutOfRangeException(nameof(index), $"Out of stack bounds: {index}/{_items.Length}");
         }
-        _referenceCounter.RemoveStackReference(_items[index]);
+        // Item moves from the evaluation stack to the slot, so it stays referenced.
+        // Skip RC on the pop (neo-go slot.store): pop first, then drop the old slot value.
         var item = stack.PopNoRef();
+        _referenceCounter.RemoveStackReference(_items[index]);
         _items[index] = item;
     }
 

--- a/tests/Neo.VM.Tests/UT_ReferenceCounter.cs
+++ b/tests/Neo.VM.Tests/UT_ReferenceCounter.cs
@@ -10,12 +10,14 @@
 // modifications are permitted.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Test.Types;
 using Neo.VM;
 using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Array = Neo.VM.Types.Array;
+using Buffer = Neo.VM.Types.Buffer;
 
 namespace Neo.Test;
 
@@ -668,5 +670,390 @@ public class UT_ReferenceCounter
         refCounter.PostExecuteInstruction();
         refCounter.AddStackReference(StackItem.Null);
         Assert.ThrowsExactly<InvalidOperationException>(() => refCounter.PostExecuteInstruction());
+    }
+
+    [TestMethod]
+    public void TestAdd_MatchesNeoGo()
+    {
+        var rc = new ReferenceCounter();
+        Assert.AreEqual(0, rc.Count);
+
+        rc.AddStackReference(StackItem.Null);
+        Assert.AreEqual(1, rc.Count);
+
+        rc.AddStackReference(StackItem.Null);
+        Assert.AreEqual(2, rc.Count); // count scalar items twice
+
+        var arr = new Array(new StackItem[] { new ByteString(new byte[] { 1 }), StackItem.False });
+        rc.AddStackReference(arr);
+        Assert.AreEqual(5, rc.Count); // array + 2 elements
+
+        rc.AddStackReference(arr);
+        Assert.AreEqual(6, rc.Count); // count only array
+
+        rc.RemoveStackReference(arr);
+        Assert.AreEqual(5, rc.Count);
+
+        rc.RemoveStackReference(arr);
+        Assert.AreEqual(2, rc.Count);
+
+        var map = new Map { [new ByteString("some"u8.ToArray())] = StackItem.False };
+        rc.AddStackReference(map);
+        Assert.AreEqual(5, rc.Count); // map + key + value
+
+        rc.AddStackReference(map);
+        Assert.AreEqual(6, rc.Count); // map only
+
+        rc.RemoveStackReference(map);
+        Assert.AreEqual(5, rc.Count);
+
+        rc.RemoveStackReference(map);
+        Assert.AreEqual(2, rc.Count);
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_DupPopItem()
+    {
+        using ScriptBuilder sb = new();
+        sb.Emit(OpCode.DUP);
+        sb.Emit(OpCode.POPITEM);
+
+        using ExecutionEngine engine = new();
+        engine.LoadScript(sb.ToArray());
+        engine.Push(new Array(new StackItem[] { 42, 42 }));
+        Assert.AreEqual(3, engine.ReferenceCounter.Count);
+
+        Assert.AreEqual(VMState.HALT, engine.Execute());
+        Assert.AreEqual(2, engine.ResultStack.Count);
+        Assert.AreEqual(3, engine.ReferenceCounter.Count);
+
+        engine.ResultStack.Pop();
+        Assert.AreEqual(1, engine.ResultStack.Count);
+        Assert.AreEqual(2, engine.ReferenceCounter.Count);
+
+        engine.ResultStack.Pop();
+        Assert.AreEqual(0, engine.ResultStack.Count);
+        Assert.AreEqual(0, engine.ReferenceCounter.Count);
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_Unpack()
+    {
+        foreach (var (name, factory) in UnpackContainers())
+        {
+            using ScriptBuilder sb = new();
+            sb.Emit(OpCode.UNPACK);
+
+            using ExecutionEngine engine = new();
+            engine.LoadScript(sb.ToArray());
+            engine.Push(factory(out int keyCount));
+            Assert.AreEqual(3 + keyCount, engine.ReferenceCounter.Count, name);
+
+            Assert.AreEqual(VMState.HALT, engine.Execute());
+            Assert.AreEqual(2 + keyCount, engine.ResultStack.Count, name);
+            Assert.AreEqual((2 + keyCount) + 1, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(2 + keyCount, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            if (name == "map")
+            {
+                Assert.AreEqual(2, engine.ReferenceCounter.Count, name);
+                engine.ResultStack.Pop();
+            }
+            Assert.AreEqual(0, engine.ResultStack.Count, name);
+            Assert.AreEqual(0, engine.ReferenceCounter.Count, name);
+        }
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_DupUnpack()
+    {
+        foreach (var (name, factory) in UnpackContainers())
+        {
+            using ScriptBuilder sb = new();
+            sb.Emit(OpCode.DUP);
+            sb.Emit(OpCode.UNPACK);
+
+            using ExecutionEngine engine = new();
+            engine.LoadScript(sb.ToArray());
+            engine.Push(factory(out int keyCount));
+            Assert.AreEqual((2 + keyCount) + 1, engine.ReferenceCounter.Count, name);
+
+            Assert.AreEqual(VMState.HALT, engine.Execute());
+            Assert.AreEqual((2 + keyCount) + 1, engine.ResultStack.Count, name);
+            Assert.AreEqual(3 + 1 + 2 * keyCount + 1, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(3 + 1 + 2 * keyCount, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            if (name == "map")
+            {
+                Assert.AreEqual(3 + 1 + keyCount, engine.ReferenceCounter.Count, name);
+                engine.ResultStack.Pop();
+            }
+            Assert.AreEqual(1, engine.ResultStack.Count, name);
+            Assert.AreEqual(3 + keyCount, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(0, engine.ResultStack.Count, name);
+            Assert.AreEqual(0, engine.ReferenceCounter.Count, name);
+        }
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_Values()
+    {
+        foreach (var (name, factory) in ValuesContainers())
+        {
+            using ScriptBuilder sb = new();
+            sb.Emit(OpCode.VALUES);
+
+            using ExecutionEngine engine = new();
+            engine.LoadScript(sb.ToArray());
+            engine.Push(factory(out int keyCount));
+            Assert.AreEqual(3 + keyCount, engine.ReferenceCounter.Count, name);
+
+            Assert.AreEqual(VMState.HALT, engine.Execute());
+            Assert.AreEqual(1, engine.ResultStack.Count, name);
+            Assert.AreEqual(3, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(0, engine.ResultStack.Count, name);
+            Assert.AreEqual(0, engine.ReferenceCounter.Count, name);
+        }
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_DupValues()
+    {
+        foreach (var (name, factory) in ValuesContainers())
+        {
+            using ScriptBuilder sb = new();
+            sb.Emit(OpCode.DUP);
+            sb.Emit(OpCode.VALUES);
+
+            using ExecutionEngine engine = new();
+            engine.LoadScript(sb.ToArray());
+            engine.Push(factory(out int keyCount));
+            Assert.AreEqual(3 + keyCount, engine.ReferenceCounter.Count, name);
+
+            Assert.AreEqual(VMState.HALT, engine.Execute());
+            Assert.AreEqual(2, engine.ResultStack.Count, name);
+            Assert.AreEqual((3 + keyCount) + 3, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(3 + keyCount, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(0, engine.ResultStack.Count, name);
+            Assert.AreEqual(0, engine.ReferenceCounter.Count, name);
+        }
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_SetItemCloneStruct()
+    {
+        foreach (var (name, factory) in SetItemCloneContainers())
+        {
+            using ScriptBuilder sb = new();
+            sb.Emit(OpCode.DUP);
+            sb.Emit(OpCode.PUSH0);
+            sb.Emit(OpCode.PUSH3);
+            sb.Emit(OpCode.PICK);
+            sb.Emit(OpCode.SETITEM);
+
+            using ExecutionEngine engine = new();
+            engine.LoadScript(sb.ToArray());
+            engine.Push(new Struct(new StackItem[] { 42 }));
+            Assert.AreEqual(2, engine.ReferenceCounter.Count, name);
+            engine.Push(factory(out int keyCount));
+            Assert.AreEqual(2 + (2 + keyCount), engine.ReferenceCounter.Count, name);
+
+            Assert.AreEqual(VMState.HALT, engine.Execute());
+            Assert.AreEqual(2, engine.ResultStack.Count, name);
+            Assert.AreEqual(2 + (3 + keyCount), engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(2, engine.ReferenceCounter.Count, name);
+
+            engine.ResultStack.Pop();
+            Assert.AreEqual(0, engine.ResultStack.Count, name);
+            Assert.AreEqual(0, engine.ReferenceCounter.Count, name);
+        }
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_PackMapSameKey_DifferentValues()
+    {
+        using ScriptBuilder sb = new();
+        sb.Emit(OpCode.PACKMAP);
+
+        using ExecutionEngine engine = new();
+        engine.LoadScript(sb.ToArray());
+        engine.Push(StackItem.Null);
+        engine.Push(new Integer(0));
+        engine.Push(new Array(new StackItem[] { 42 }));
+        engine.Push(new Integer(0));
+        engine.Push(new Integer(2));
+        Assert.AreEqual(5, engine.CurrentContext!.EvaluationStack.Count);
+        Assert.AreEqual((1 + 1) + (2 + 1) + 1, engine.ReferenceCounter.Count);
+
+        Assert.AreEqual(VMState.HALT, engine.Execute());
+        Assert.AreEqual(1, engine.ResultStack.Count);
+        Assert.AreEqual(1 + (1 + 1), engine.ReferenceCounter.Count);
+
+        engine.ResultStack.Pop();
+        Assert.AreEqual(0, engine.ResultStack.Count);
+        Assert.AreEqual(0, engine.ReferenceCounter.Count);
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_PackMapSameKey_SameValues()
+    {
+        using ScriptBuilder sb = new();
+        sb.Emit(OpCode.PACKMAP);
+
+        using ExecutionEngine engine = new();
+        engine.LoadScript(sb.ToArray());
+        var arr = new Array(new StackItem[] { 42 });
+        engine.Push(arr);
+        engine.Push(new Integer(0));
+        engine.Push(arr);
+        engine.Push(new Integer(0));
+        engine.Push(new Integer(2));
+        Assert.AreEqual(5, engine.CurrentContext!.EvaluationStack.Count);
+        Assert.AreEqual((2 + 1) + (1 + 1) + 1, engine.ReferenceCounter.Count);
+
+        Assert.AreEqual(VMState.HALT, engine.Execute());
+        Assert.AreEqual(1, engine.ResultStack.Count);
+        Assert.AreEqual(1 + (1 + 2), engine.ReferenceCounter.Count);
+
+        engine.ResultStack.Pop();
+        Assert.AreEqual(0, engine.ResultStack.Count);
+        Assert.AreEqual(0, engine.ReferenceCounter.Count);
+    }
+
+    [TestMethod]
+    public void TestCheckZeroReferred_SetItemException()
+    {
+        using ScriptBuilder sb = new();
+        sb.Emit(OpCode.TRY, new byte[] { 4, 0 });
+        sb.Emit(OpCode.SETITEM);
+
+        using ExecutionEngine engine = new();
+        engine.LoadScript(sb.ToArray());
+        engine.Push(new Buffer(0));
+        engine.Push(new Integer(0));
+        engine.Push(new Array(new StackItem[] { 42 }));
+        Assert.AreEqual(3, engine.CurrentContext!.EvaluationStack.Count);
+        Assert.AreEqual(1 + 1 + 2, engine.ReferenceCounter.Count);
+
+        Assert.AreEqual(VMState.HALT, engine.Execute());
+        Assert.AreEqual(1, engine.ResultStack.Count);
+        Assert.AreEqual(1, engine.ReferenceCounter.Count);
+    }
+
+    [TestMethod]
+    public void TestNegativeRC_CircularClearItemsCannotUnderflow()
+    {
+        // Port of neo-go TestNegativeRC / nspcc-dev/neo-go#4312 and neo-vm#580:
+        // CLEARITEMS on a self-referential array must not drive RC negative,
+        // otherwise MaxStackSize can be bypassed.
+        byte[] prog =
+        [
+            (byte)OpCode.INITSLOT, 0x01, 0x00,
+            (byte)OpCode.PUSH16, (byte)OpCode.INC, (byte)OpCode.STLOC0,
+            (byte)OpCode.NEWARRAY0,
+            (byte)OpCode.DUP,
+            (byte)OpCode.DUP,
+            (byte)OpCode.APPEND,
+            (byte)OpCode.CLEARITEMS,
+            (byte)OpCode.LDLOC0, (byte)OpCode.DEC, (byte)OpCode.DUP,
+            (byte)OpCode.STLOC0, (byte)OpCode.PUSH0,
+            (byte)OpCode.JMPGT, 0xf6,
+            (byte)OpCode.PUSH16, (byte)OpCode.PUSH7, (byte)OpCode.SHL, (byte)OpCode.PUSH14, (byte)OpCode.ADD, (byte)OpCode.STLOC0,
+            (byte)OpCode.PUSH0,
+            (byte)OpCode.LDLOC0, (byte)OpCode.DEC, (byte)OpCode.DUP,
+            (byte)OpCode.STLOC0, (byte)OpCode.PUSH0,
+            (byte)OpCode.JMPGT, 0xfa,
+        ];
+
+        using var engine = new TestEngine();
+        engine.LoadScript(prog);
+        Assert.AreEqual(VMState.FAULT, engine.Execute());
+        Assert.IsNotNull(engine.FaultException);
+        Assert.AreEqual($"MaxStackSize exceed: {ExecutionEngineLimits.Default.MaxStackSize + 1}/{ExecutionEngineLimits.Default.MaxStackSize}", engine.FaultException.Message);
+        Assert.AreEqual((int)ExecutionEngineLimits.Default.MaxStackSize + 1, engine.ReferenceCounter.Count);
+    }
+
+    private delegate StackItem ContainerFactory(out int keyCount);
+
+    private static (string Name, ContainerFactory Factory)[] UnpackContainers()
+    {
+        return
+        [
+            ("array", (out int keyCount) =>
+            {
+                keyCount = 0;
+                return new Array(new StackItem[] { new Array(new StackItem[] { 42 }) });
+            }),
+            ("struct", (out int keyCount) =>
+            {
+                keyCount = 0;
+                return new Struct(new StackItem[] { new Array(new StackItem[] { 42 }) });
+            }),
+            ("map", (out int keyCount) =>
+            {
+                keyCount = 1;
+                return new Map { [new Integer(0)] = new Array(new StackItem[] { 42 }) };
+            }),
+        ];
+    }
+
+    private static (string Name, ContainerFactory Factory)[] ValuesContainers()
+    {
+        return
+        [
+            ("array", (out int keyCount) =>
+            {
+                keyCount = 0;
+                return new Array(new StackItem[] { new Struct(new StackItem[] { 42 }) });
+            }),
+            ("struct", (out int keyCount) =>
+            {
+                keyCount = 0;
+                return new Struct(new StackItem[] { new Struct(new StackItem[] { 42 }) });
+            }),
+            ("map", (out int keyCount) =>
+            {
+                keyCount = 1;
+                return new Map { [new Integer(0)] = new Struct(new StackItem[] { 42 }) };
+            }),
+        ];
+    }
+
+    private static (string Name, ContainerFactory Factory)[] SetItemCloneContainers()
+    {
+        return
+        [
+            ("array", (out int keyCount) =>
+            {
+                keyCount = 0;
+                return new Array(new StackItem[] { StackItem.Null });
+            }),
+            ("struct", (out int keyCount) =>
+            {
+                keyCount = 0;
+                return new Struct(new StackItem[] { StackItem.Null });
+            }),
+            ("map", (out int keyCount) =>
+            {
+                keyCount = 1;
+                return new Map { [new Integer(0)] = StackItem.Null };
+            }),
+        ];
     }
 }

--- a/tests/Neo.VM.Tests/UT_ReferenceCounterComprehensive.cs
+++ b/tests/Neo.VM.Tests/UT_ReferenceCounterComprehensive.cs
@@ -502,6 +502,24 @@ public class UT_ReferenceCounterComprehensive
         Assert.AreEqual(1, engine.ReferenceCounter.Count);
     }
 
+    [TestMethod]
+    public void TestSlotStore_FailedPop_DoesNotCorruptRefCounter()
+    {
+        using ScriptBuilder sb = new();
+        sb.Emit(OpCode.INITSLOT, new byte[] { 1, 0 });
+        sb.EmitPush(42);
+        sb.Emit(OpCode.STLOC0);
+        sb.Emit(OpCode.STLOC0);
+
+        using var engine = new ExecutionEngine();
+        engine.LoadScript(sb.ToArray());
+
+        Assert.AreEqual(VMState.FAULT, engine.Execute());
+        // First STLOC0 stores 42; second STLOC0 pops an empty stack and FAULTs.
+        // Slot.Store pops before dropping the old slot value, so 42 stays referenced.
+        Assert.AreEqual(1, engine.ReferenceCounter.Count);
+    }
+
     #endregion
 
     #region 8. Stress Tests

--- a/tests/Neo.VM.Tests/UT_ReferenceCounterComprehensive.cs
+++ b/tests/Neo.VM.Tests/UT_ReferenceCounterComprehensive.cs
@@ -460,8 +460,7 @@ public class UT_ReferenceCounterComprehensive
         engine.LoadScript(sb.ToArray());
 
         Assert.AreEqual(VMState.HALT, engine.Execute());
-        // Null is not tracked (not CompoundType or Buffer), so count is 0
-        // This verifies that non-tracked types don't affect the reference count
+        // INITSLOT counts the Null placeholders; RET unloads the slot and drops them.
         Assert.AreEqual(0, engine.ReferenceCounter.Count);
     }
 


### PR DESCRIPTION
## Summary

Finish remaining neo-go opcode-level reference-counter parity and port the tests that lock that model in. Light RC is already on master (`#564`, `#575`, `#581`).

## Slot store (neo-go `slot.store`)

An item that moves from the evaluation stack into a slot stays referenced. `Slot.Store` pops with `PopNoRef` first, then drops the previous slot value. Matches [nspcc-dev/neo-go `pkg/vm/slot.go`](https://github.com/nspcc-dev/neo-go/blob/master/pkg/vm/slot.go).

## Counter model (documented)

Same as [nspcc-dev/neo-go `pkg/vm/ref_counter.go`](https://github.com/nspcc-dev/neo-go/blob/master/pkg/vm/ref_counter.go) (`IncRC` / `DecRC` / `IsReferenced`):

- Always increment the global count on add.
- Recurse into array/struct items and map keys+values only on 0→1 / last→0.
- Skip `Remove` on an unreferenced compound so cyclic graphs cannot drive RC negative and bypass `MaxStackSize` ([neo-go#4312](https://github.com/nspcc-dev/neo-go/pull/4312), [neo-vm#580](https://github.com/neo-project/neo-vm/issues/580)).

## Tests ported from neo-go `ref_counter_test.go`

- Direct `Add`/`Remove` on scalars, arrays, and maps (keys counted)
- `DUP`+`POPITEM`, `UNPACK`/`VALUES` (plain and `DUP`), `SETITEM` struct clone
- `PACKMAP` with the same key (different values / same value)
- `TRY`+`SETITEM` exception path
- `TestNegativeRC`: self-referential `APPEND`/`CLEARITEMS` loop must FAULT at `MaxStackSize+1`, not underflow
